### PR TITLE
Add hide_code keyword argument

### DIFF
--- a/src/build.jl
+++ b/src/build.jl
@@ -18,22 +18,14 @@ function _notebook_done(notebook::Notebook)
 end
 
 """
-    parallel_build!(
-        dir,
-        files;
-        print_log=true,
-        session=ServerSession()
-    )
+    parallel_build!(dir, files; session=ServerSession(), kwargs...)
 
 Build HTML files in parallel and write output to files with a ".html" extension.
-This can be useful to speed up the build locally or in CI.
+The `kwargs` are passed to `notebook2html`.
+
+This method can be useful to speed up the build locally or in CI.
 """
-function parallel_build!(
-        dir,
-        files;
-        print_log=true,
-        session=ServerSession()
-    )
+function parallel_build!(dir, files; session=ServerSession(), kwargs...)
 
     # Start all the notebooks in parallel with async enabled.
     # This way, Pluto handles concurrency.
@@ -55,7 +47,7 @@ function parallel_build!(
         out_file = "$(without_extension).html"
         out_path = joinpath(dir, out_file)
 
-        html = notebook2html(notebook)
+        html = notebook2html(notebook; kwargs...)
         SessionActions.shutdown(session, notebook)
         write(out_path, html)
     end
@@ -63,8 +55,13 @@ function parallel_build!(
     return nothing
 end
 
-function parallel_build!(dir; print_log=true)
+"""
+    parallel_build!(dir; kwargs...)
+
+Build all ".jl" files in `dir` in parallel.
+"""
+function parallel_build!(dir; kwargs...)
     files = filter(endswith(".jl"), readdir(dir))
-    parallel_build!(dir, files; print_log)
+    parallel_build!(dir, files; kwargs...)
     return nothing
 end

--- a/src/html.jl
+++ b/src/html.jl
@@ -220,25 +220,13 @@ function notebook2html(
 end
 
 """
-    notebook2html(
-        path::AbstractString;
-        code_class="language-julia",
-        output_class="code-output",
-        hide_md_code=true,
-        hide_code=false,
-        session=ServerSession()
-    )
+    notebook2html(path::AbstractString; session=ServerSession(), kwargs...)
 
 Run the Pluto notebook at `path` and return the code and output as HTML.
+The `kwargs` are passed to `notebook2html(notebook::Notebook, kwargs...)`.
 """
-function notebook2html(
-        path::AbstractString;
-        code_class="language-julia",
-        output_class="code-output",
-        hide_md_code=true,
-        hide_code=false,
-        session=ServerSession()
-    )
+function notebook2html(path::AbstractString; session=ServerSession(), kwargs...)
     notebook = SessionActions.open(session, path; run_async=false)
-    html = notebook2html(notebook; code_class, output_class, hide_md_code, hide_code)
+    html = notebook2html(notebook; kwargs...)
+    return html
 end

--- a/src/html.jl
+++ b/src/html.jl
@@ -41,7 +41,10 @@ function output_block(s; class="code-output")
     return """<pre><code class="$class">$s</code></pre>"""
 end
 
-function _code2html(code::AbstractString, class, hide_md_code)
+function _code2html(code::AbstractString, class, hide_md_code, hide_code)
+    if hide_code
+        return ""
+    end
     if hide_md_code && startswith(code, "md\"")
         return ""
     end
@@ -173,8 +176,8 @@ _output2html(body, ::MIME"text/plain", class) = output_block(body)
 _output2html(body, ::MIME"text/html", class) = body
 _output2html(body, T::MIME, class) = error("Unknown type: $T")
 
-function _cell2html(cell::Cell, code_class, output_class, hide_md_code)
-    code = _code2html(cell.code, code_class, hide_md_code)
+function _cell2html(cell::Cell, code_class, output_class, hide_md_code, hide_code)
+    code = _code2html(cell.code, code_class, hide_md_code, hide_code)
     output = _output2html(cell.output.body, cell.output.mime, output_class)
     return """
         $code
@@ -193,6 +196,7 @@ end
         notebook::Notebook;
         code_class="language-julia",
         output_class="code-output",
+        hide_code=false,
         hide_md_code=true
     )
 
@@ -203,12 +207,13 @@ function notebook2html(
         notebook::Notebook;
         code_class="language-julia",
         output_class="code-output",
+        hide_code=false,
         hide_md_code=true
     )
     order = notebook.cell_order
     outputs = map(order) do cell_uuid
         cell = notebook.cells_dict[cell_uuid]
-        _cell2html(cell, code_class, output_class, hide_md_code)
+        _cell2html(cell, code_class, output_class, hide_md_code, hide_code)
     end
     html = join(outputs, '\n')
     return html
@@ -219,6 +224,8 @@ end
         path::AbstractString;
         code_class="language-julia",
         output_class="code-output",
+        hide_md_code=true,
+        hide_code=false,
         session=ServerSession()
     )
 
@@ -228,8 +235,10 @@ function notebook2html(
         path::AbstractString;
         code_class="language-julia",
         output_class="code-output",
+        hide_md_code=true,
+        hide_code=false,
         session=ServerSession()
     )
     notebook = SessionActions.open(session, path; run_async=false)
-    html = notebook2html(notebook)
+    html = notebook2html(notebook; code_class, output_class, hide_md_code, hide_code)
 end

--- a/test/html.jl
+++ b/test/html.jl
@@ -69,6 +69,10 @@ end
     html = notebook2html!(notebook; hide_md_code=false)
     lines = split(html, '\n')
     @test lines[1] != ""
+
+    html = notebook2html!(notebook; hide_md_code=false, hide_code=true)
+    lines = split(html, '\n')
+    @test lines[1] == ""
 end
 
 @testset "from_file" begin


### PR DESCRIPTION
Useful for situations when you know that the reader is not interested in code. Setting `hide_code=true` will hide all code blocks.