### PR TITLE
Add `append_cells` keyword argument

### DIFF
--- a/src/html.jl
+++ b/src/html.jl
@@ -185,6 +185,18 @@ function _cell2html(cell::Cell, code_class, output_class, hide_md_code, hide_cod
         """
 end
 
+"""
+    _append_cell!(notebook::Notebook, cell::Cell)
+
+Add one `cell` to the end of the `notebook`.
+This is based on `add_remote_cell` in Pluto's `Editor.js`.
+"""
+function _append_cell!(notebook::Notebook, cell::Cell)
+    push!(notebook.cell_order, cell.cell_id)
+    notebook.cells_dict[cell.cell_id] = cell
+    return notebook
+end
+
 function run_notebook!(notebook, session; run_async=false)
     cells = [last(e) for e in notebook.cells_dict]
     update_save_run!(session, notebook, cells; run_async)

--- a/test/html.jl
+++ b/test/html.jl
@@ -1,9 +1,3 @@
-function notebook2html!(notebook; kwargs...)
-    session = ServerSession()
-    run_notebook!(notebook, session)
-    return notebook2html(notebook; kwargs...)
-end
-
 @testset "html" begin
     html = "<b>foo</b>"
     block = PlutoStaticHTML.code_block(html)
@@ -83,4 +77,15 @@ end
         html = notebook2html(file)
         @test contains(html, "3")
     end
+end
+
+@testset "append_cell" begin
+    notebook = Notebook([
+        Cell("x = 600 + 1"),
+    ])
+    new_cell = Cell("y = 600 + 2")
+    PlutoStaticHTML._append_cell!(notebook, new_cell)
+    html = notebook2html!(notebook)
+    @test contains(html, "601")
+    @test contains(html, "602")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,5 +25,11 @@ function pluto_notebook_content(code)
         """
 end
 
+function notebook2html!(notebook; kwargs...)
+    session = ServerSession()
+    run_notebook!(notebook, session)
+    return notebook2html(notebook; kwargs...)
+end
+
 include("html.jl")
 include("build.jl")


### PR DESCRIPTION
Allow appending of cells to the end of a notebook. This can, for example, be useful to show package versions below every notebook.