### PR TITLE
Add state to each output and add `HTMLOptions`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 Pluto = "0.16, 0.17"

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "2.1.1"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [compat]
 Pluto = "0.16, 0.17"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@
 
 A [Julia package](https://julialang.org/) to convert [Pluto notebooks](https://github.com/fonsp/Pluto.jl) to static HTML. Unlike [PlutoSliderServer](https://github.com/JuliaPluto/PlutoSliderServer.jl), the HTML files generated using PlutoStaticHTML are very minimal, and do not require JavaScript on the user side to render. This also makes it easier to style the output using CSS.
 
-This package also provides an easy interface for parallel evaluation of notebooks 🚀.
+## Automated builds
+
+Next to outputting pure HTML, this package is also aimed at building multiple Pluto.jl notebooks as reliably and quickly as possible in CI.
+Therefore, this package implements:
+
+1. Parallel evaluation of notebooks 🚀.
+2. Caching of notebooks to avoid re-running code if nothing changed 🚀.
+3. Throwing an error if something goes wrong.
+    This avoids publishing broken notebooks 🎯.
 
 See the [documentation](https://rikhuijzer.github.io/PlutoStaticHTML.jl/dev/) for more information.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A [Julia package](https://julialang.org/) to convert [Pluto notebooks](https://g
 
 ## Automated builds
 
-Next to outputting pure HTML, this package is also aimed at building multiple Pluto.jl notebooks as reliably and quickly as possible in CI.
+Next to outputting static HTML, this package is also aimed at building multiple Pluto.jl notebooks as reliably and quickly as possible in CI.
 Therefore, this package implements:
 
 1. Parallel evaluation of notebooks 🚀.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,8 +18,8 @@ Probably similar cause as https://github.com/JuliaDocs/Documenter.jl/issues/1514
 """
 function write_notebook()
     @info "Running notebook at $NOTEBOOK_PATH"
-    append_build_context = true
-    html = notebook2html(NOTEBOOK_PATH; append_build_context)
+    opts = HTMLOptions(; append_build_context=true)
+    html = notebook2html(NOTEBOOK_PATH, opts)
     md_path = joinpath(NOTEBOOK_DIR, "notebook.md")
     md = """
         ```@eval

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,8 +6,6 @@ Small discussion with Fons van der Plas at <https://github.com/fonsp/Pluto.jl/di
 I'm using this package for my own blog, for example: <https://huijzer.xyz/posts/frequentist-bayesian-coin-flipping/>.
 A link to the notebook is at the bottom of the page.
 
-See the [Example notebook](@ref) for how the output of PlutoStaticHTML looks.
-
 ### notebook2html
 
 The most important methods are `notebook2html` or `parallel_build!` ([API](@ref)).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,7 +10,7 @@ See the [Example notebook](@ref) for how the output of PlutoStaticHTML looks.
 
 ### notebook2html
 
-The most important methods are `notebook2html` or `parallel_build!` ([Docstrings](@ref)).
+The most important methods are `notebook2html` or `parallel_build!` ([API](@ref)).
 
 !!! note
     `notebook2html` and `parallel_build!` do **not** change the original notebook file.
@@ -37,7 +37,7 @@ More specific instructions for
 - [Documenter.jl](@ref)
 - [Franklin.jl](@ref)
 - [Parallel build](@ref)
-- [Docstrings](@ref)
+- [API](@ref)
 
 are listed below.
 
@@ -185,11 +185,10 @@ With Franklin.jl, update `foot_katex.html` to include:
 which basically ensures that inline math surrounded by single dollar symbols is also rendered.
 Note that Pluto.jl runs MathJax by default which might sometimes cause inconsistencies between the math in Pluto and inside your HTML.
 
-## Docstrings
-
-`kwargs` for `notebook2html(path; ...)` and `parallel_build!` are passed to `notebook2html`:
+## API
 
 ```@docs
+HTMLOptions
 parallel_build!
 notebook2html
 ```

--- a/src/PlutoStaticHTML.jl
+++ b/src/PlutoStaticHTML.jl
@@ -1,5 +1,7 @@
 module PlutoStaticHTML
 
+import Base: string
+
 using Base64: base64encode
 using Pkg:
     Types.Context,
@@ -19,9 +21,11 @@ using Pluto:
     update_dependency_cache!,
     update_run!,
     update_save_run!
+using SHA: sha256
 
 include("module_doc.jl")
 include("context.jl")
+include("cache.jl")
 include("html.jl")
 include("build.jl")
 

--- a/src/PlutoStaticHTML.jl
+++ b/src/PlutoStaticHTML.jl
@@ -30,7 +30,7 @@ include("cache.jl")
 include("html.jl")
 include("build.jl")
 
-export notebook2html, run_notebook!
+export HTMLOptions, notebook2html, run_notebook!
 export parallel_build!
 
 end # module

--- a/src/PlutoStaticHTML.jl
+++ b/src/PlutoStaticHTML.jl
@@ -22,6 +22,7 @@ using Pluto:
     update_run!,
     update_save_run!
 using SHA: sha256
+using TOML: parse as parsetoml
 
 include("module_doc.jl")
 include("context.jl")

--- a/src/build.jl
+++ b/src/build.jl
@@ -25,7 +25,8 @@ end
         session=ServerSession()
     )
 
-Build HTML files in parallel and write output to files with a ".html" extension.
+Build Pluto notebooks in `dir` to HTML files in parallel and write output to `dir`.
+Output ffiles have a ".html" extension.
 The shebang (`!`) is added because this function may create new HTML files or alter existing HTML files.
 
 This method can be useful to speed up the build locally or in CI.

--- a/src/build.jl
+++ b/src/build.jl
@@ -18,15 +18,24 @@ function _notebook_done(notebook::Notebook)
 end
 
 """
-    parallel_build!(dir, files; session=ServerSession(), kwargs...)
+    parallel_build!(
+        dir,
+        files;
+        opts::HTMLOptions=HTMLOptions(),
+        session=ServerSession()
+    )
 
 Build HTML files in parallel and write output to files with a ".html" extension.
-The shebang is added because this function may create new HTML files or alter existing HTML files.
-The `kwargs` are passed to `notebook2html`.
+The shebang (`!`) is added because this function may create new HTML files or alter existing HTML files.
 
 This method can be useful to speed up the build locally or in CI.
 """
-function parallel_build!(dir, files; session=ServerSession(), kwargs...)
+function parallel_build!(
+        dir,
+        files;
+        opts::HTMLOptions=HTMLOptions(),
+        session=ServerSession()
+    )
 
     # Start all the notebooks in parallel with async enabled.
     # This way, Pluto handles concurrency.
@@ -48,7 +57,7 @@ function parallel_build!(dir, files; session=ServerSession(), kwargs...)
         out_file = "$(without_extension).html"
         out_path = joinpath(dir, out_file)
 
-        html = notebook2html(notebook; kwargs...)
+        html = notebook2html(notebook, opts)
         SessionActions.shutdown(session, notebook)
         write(out_path, html)
     end

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -15,11 +15,13 @@ function n_cache_lines()
     return length(lines)
 end
 
+const CACHE_IDENTIFIER = "[PlutoStaticHTML.State]"
+
 function string(state::State)::String
     return """
         <!--
             # This information is used for caching.
-            [PlutoStaticHTML.State]
+            $CACHE_IDENTIFIER
             input_sha = "$(state.input_sha)"
             julia_version = "$(state.julia_version)"
         -->
@@ -30,7 +32,7 @@ end
 function extract_state(html::AbstractString)::State
     sep = '\n'
     lines = split(html, sep)
-    start = findfirst(contains("[PlutoStaticHTML.State]"), lines)
+    start = findfirst(contains(CACHE_IDENTIFIER), lines)
     stop = start + 2
     info = join(lines[start:stop], sep)
     entries = parsetoml(info)["PlutoStaticHTML"]["State"]

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -1,0 +1,21 @@
+sha(s) = bytes2hex(sha256(s))
+path2sha(path::AbstractString) = sha(read(path))
+
+struct State
+    input_sha::String
+    julia_version::String
+end
+
+State(html::AbstractString) = State(sha(html), VERSION)
+
+function string(state::State)::String
+    return """
+        <!--
+            # This information is used for caching.
+            [PlutoStaticHTML.State]
+            input_sha = "$(state.input_sha)"
+            julia_version = "$(state.julia_version)"
+        -->
+        """
+end
+

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -9,6 +9,12 @@ end
 "Create a new State from a HTML file."
 State(html::AbstractString) = State(sha(html), string(VERSION))
 
+function n_cache_lines()
+    state = State("a", "b")
+    lines = split(string(state), '\n')
+    return length(lines)
+end
+
 function string(state::State)::String
     return """
         <!--

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -6,7 +6,8 @@ struct State
     julia_version::String
 end
 
-State(html::AbstractString) = State(sha(html), VERSION)
+"Create a new State from a HTML file."
+State(html::AbstractString) = State(sha(html), string(VERSION))
 
 function string(state::State)::String
     return """
@@ -19,3 +20,13 @@ function string(state::State)::String
         """
 end
 
+"Extract State from a HTML file which contains a State as string somewhere."
+function extract_state(html::AbstractString)::State
+    sep = '\n'
+    lines = split(html, sep)
+    start = findfirst(contains("[PlutoStaticHTML.State]"), lines)
+    stop = start + 2
+    info = join(lines[start:stop], sep)
+    entries = parsetoml(info)["PlutoStaticHTML"]["State"]
+    return State(entries["input_sha"], entries["julia_version"])
+end

--- a/src/html.jl
+++ b/src/html.jl
@@ -26,6 +26,10 @@ const IMAGEMIME = Union{
     Whether to omit all code blocks.
     Can be useful when readers are not interested in code at all.
 - `hide_md_code::Bool=true`: Whether to omit all Markdown code blocks.
+- `add_state::Bool=true`:
+    Whether to add a comment in HTML with the state of the input notebook.
+    This state can be used for caching.
+    Specifically, this state stores a checksum of the input notebook and the Julia version.
 - `append_build_context=false`: Whether to append build context.
     When set to `true`, this adds information about the dependencies and Julia version.
     This is not executed via Pluto.jl's evaluation to avoid having to add extra dependencies to existing notebooks.
@@ -36,6 +40,7 @@ struct HTMLOptions
     output_class::String
     hide_code::Bool
     hide_md_code::Bool
+    add_state::Bool
     append_build_context::Bool
 
     function HTMLOptions(;
@@ -43,6 +48,7 @@ struct HTMLOptions
         output_class="code-output",
         hide_code=false,
         hide_md_code=true,
+        add_state=true,
         append_build_context=false
     )
         return new(
@@ -50,6 +56,7 @@ struct HTMLOptions
             output_class,
             hide_code,
             hide_md_code,
+            add_state,
             append_build_context
         )
     end
@@ -264,7 +271,9 @@ function notebook2html(notebook::Notebook, opts::HTMLOptions=HTMLOptions())::Str
         _cell2html(cell, opts)
     end
     html = join(outputs, '\n')
-    html = string(State(html)) * html
+    if opts.add_state
+        html = string(State(html)) * html
+    end
     if opts.append_build_context
         html = html * _context(notebook)
     end

--- a/src/html.jl
+++ b/src/html.jl
@@ -245,7 +245,8 @@ function notebook2html(
         cell = notebook.cells_dict[cell_uuid]
         _cell2html(cell, code_class, output_class, hide_md_code, hide_code)
     end
-    html = string(State(html)) * join(outputs, '\n')
+    html = join(outputs, '\n')
+    html = string(State(html)) * html
     if append_build_context
         html = html * _context(notebook)
     end

--- a/src/html.jl
+++ b/src/html.jl
@@ -14,6 +14,48 @@ const IMAGEMIME = Union{
 }
 
 """
+    struct HTMLOptions
+
+- `code_class::String="language-julia"`:
+    HTML class for code.
+    This is used by CSS and/or the syntax highlighter.
+- `output_class::String="code-output"`:
+    HTML class for output.
+    This is used by CSS and/or the syntax highlighter.
+- `hide_code::Bool=false`:
+    Whether to omit all code blocks.
+    Can be useful when readers are not interested in code at all.
+- `hide_md_code::Bool=true`: Whether to omit all Markdown code blocks.
+- `append_build_context=false`: Whether to append build context.
+    When set to `true`, this adds information about the dependencies and Julia version.
+    This is not executed via Pluto.jl's evaluation to avoid having to add extra dependencies to existing notebooks.
+    Instead, this reads the manifest from the notebook file.
+"""
+struct HTMLOptions
+    code_class::String
+    output_class::String
+    hide_code::Bool
+    hide_md_code::Bool
+    append_build_context::Bool
+
+    function HTMLOptions(;
+        code_class="language-julia",
+        output_class="code-output",
+        hide_code=false,
+        hide_md_code=true,
+        append_build_context=false
+    )
+        return new(
+            code_class,
+            output_class,
+            hide_code,
+            hide_md_code,
+            append_build_context
+        )
+    end
+end
+
+"""
     _escape_html(s::AbstractString)
 
 Escape HTML.
@@ -26,12 +68,12 @@ function _escape_html(s::AbstractString)
     return s
 end
 
-function code_block(code; class="language-julia")
+function code_block(code; code_class="language-julia")
     if code == ""
         return ""
     end
     code = _escape_html(code)
-    return """<pre><code class="$class">$code</code></pre>"""
+    return """<pre><code class="$code_class">$code</code></pre>"""
 end
 
 function output_block(s; class="code-output")
@@ -41,11 +83,11 @@ function output_block(s; class="code-output")
     return """<pre><code class="$class">$s</code></pre>"""
 end
 
-function _code2html(code::AbstractString, class, hide_md_code, hide_code)
-    if hide_code
+function _code2html(code::AbstractString, opts::HTMLOptions)
+    if opts.hide_code
         return ""
     end
-    if hide_md_code && startswith(code, "md\"")
+    if opts.hide_md_code && startswith(code, "md\"")
         return ""
     end
     if contains(code, "# hideall")
@@ -55,7 +97,7 @@ function _code2html(code::AbstractString, class, hide_md_code, hide_code)
     lines = split(code, sep)
     filter!(!endswith("# hide"), lines)
     code = join(lines, sep)
-    return code_block(code; class)
+    return code_block(code; opts.code_class)
 end
 
 function _output2html(body, T::IMAGEMIME, class)
@@ -176,9 +218,9 @@ _output2html(body, ::MIME"text/plain", class) = output_block(body)
 _output2html(body, ::MIME"text/html", class) = body
 _output2html(body, T::MIME, class) = error("Unknown type: $T")
 
-function _cell2html(cell::Cell, code_class, output_class, hide_md_code, hide_code)
-    code = _code2html(cell.code, code_class, hide_md_code, hide_code)
-    output = _output2html(cell.output.body, cell.output.mime, output_class)
+function _cell2html(cell::Cell, opts::HTMLOptions)
+    code = _code2html(cell.code, opts)
+    output = _output2html(cell.output.body, cell.output.mime, opts.output_class)
     return """
         $code
         $output
@@ -209,45 +251,21 @@ function run_notebook!(notebook, session; run_async=false)
 end
 
 """
-    notebook2html(
-        notebook::Notebook;
-        code_class="language-julia",
-        output_class="code-output",
-        hide_code=false,
-        hide_md_code=true,
-        append_build_context=false
-    ) -> String
+    notebook2html(notebook::Notebook, opts::HTMLOptions=HTMLOptions()) -> String
 
 Return the code and output as HTML for `notebook`.
 This method does **not** alter the notebook at `path`; it makes a copy.
 Assumes that the notebook has already been executed.
-
-Keyword arguments:
-
-- `code_class`: Code class used by CSS and/or the syntax highlighter.
-- `output_class`: Output class used by CSS and/or the syntax highlighter.
-- `hide_code`: Hide code. Can be useful when readers are not interested in code at all.
-- `hide_md_code`: Hide code for Markdown blocks. Enabled by default.
-- `append_build_context`: Append build context to the end of each output.
-    This is not executed via Pluto.jl's evaluation to avoid having to add extra dependencies to existing notebooks.
-    Instead, this reads the manifest from the notebook file.
 """
-function notebook2html(
-        notebook::Notebook;
-        code_class="language-julia",
-        output_class="code-output",
-        hide_code=false,
-        hide_md_code=true,
-        append_build_context=false
-    )::String
+function notebook2html(notebook::Notebook, opts::HTMLOptions=HTMLOptions())::String
     order = notebook.cell_order
     outputs = map(order) do cell_uuid
         cell = notebook.cells_dict[cell_uuid]
-        _cell2html(cell, code_class, output_class, hide_md_code, hide_code)
+        _cell2html(cell, opts)
     end
     html = join(outputs, '\n')
     html = string(State(html)) * html
-    if append_build_context
+    if opts.append_build_context
         html = html * _context(notebook)
     end
     return string(html)::String
@@ -262,21 +280,30 @@ function _load_notebook(path::AbstractString)
 end
 
 """
-    notebook2html(path::AbstractString; session=ServerSession(), append_cells=Cell[], kwargs...) -> String
+    notebook2html(
+        path::AbstractString,
+        opts::HTMLOptions=HTMLOptions();
+        session=ServerSession(),
+        append_cells=Cell[],
+    ) -> String
 
 Run the Pluto notebook at `path` and return the code and output as HTML.
 This makes a copy of the notebook at `path` and runs it.
-The `kwargs` are passed to `notebook2html(notebook::Notebook, kwargs...)`.
 
 Keyword arguments:
 
 - `append_cells`: Specify one or more `Pluto.Cell`s to be appended at the end of the notebook.
     Be careful when adding new packages via this method because it may disable Pluto.jl's built-in package management.
 """
-function notebook2html(path::AbstractString; session=ServerSession(), append_cells=Cell[], kwargs...)::String
+function notebook2html(
+        path::AbstractString,
+        opts::HTMLOptions=HTMLOptions();
+        session=ServerSession(),
+        append_cells=Cell[],
+    )::String
     notebook = _load_notebook(path)
     PlutoStaticHTML._append_cell!(notebook, append_cells)
     run_notebook!(notebook, session; run_async=false)
-    html = notebook2html(notebook; kwargs...)
+    html = notebook2html(notebook, opts)
     return html
 end

--- a/src/html.jl
+++ b/src/html.jl
@@ -245,7 +245,7 @@ function notebook2html(
         cell = notebook.cells_dict[cell_uuid]
         _cell2html(cell, code_class, output_class, hide_md_code, hide_code)
     end
-    html = join(outputs, '\n')
+    html = string(State(html)) * join(outputs, '\n')
     if append_build_context
         html = html * _context(notebook)
     end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
+PlutoStaticHTML = "359b1769-a58e-495b-9770-312e911026ad"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,3 @@
 [deps]
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
-PlutoStaticHTML = "359b1769-a58e-495b-9770-312e911026ad"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/cache.jl
+++ b/test/cache.jl
@@ -1,7 +1,7 @@
 @testset "prefix" begin
     version = $VERSION
     text = repeat("foobar\n", 100)
-    html = string(PlutoStaticHTML.State(html)) * text
+    html = string(PlutoStaticHTML.State(text)) * text
     state = PlutoStaticHTML.State(html)
     @test state.input_sha == PlutoStaticHTML.sha(html)
     @test state.julia_version == string(VERSION)::String

--- a/test/cache.jl
+++ b/test/cache.jl
@@ -1,0 +1,8 @@
+@testset "prefix" begin
+    version = $VERSION
+    text = repeat("foobar\n", 100)
+    html = string(PlutoStaticHTML.State(html)) * text
+    state = PlutoStaticHTML.State(html)
+    @test state.input_sha == PlutoStaticHTML.sha(html)
+    @test state.julia_version == string(VERSION)::String
+end

--- a/test/cache.jl
+++ b/test/cache.jl
@@ -1,8 +1,8 @@
 @testset "prefix" begin
-    version = $VERSION
+    version = VERSION
     text = repeat("foobar\n", 100)
     html = string(PlutoStaticHTML.State(text)) * text
     state = PlutoStaticHTML.State(html)
     @test state.input_sha == PlutoStaticHTML.sha(html)
-    @test state.julia_version == string(VERSION)::String
+    @test state.julia_version == string(VERSION)
 end

--- a/test/context.jl
+++ b/test/context.jl
@@ -1,6 +1,7 @@
 @testset "context" begin
     notebook = PlutoStaticHTML._load_notebook(NOTEBOOK_PATH)
-    html = notebook2html!(notebook; append_build_context=true)
+    opts = HTMLOptions(; append_build_context=true)
+    html = notebook2html_helper(notebook, opts)
     @test contains(html, r"Built with Julia 1.*")
     @test contains(html, "CairoMakie")
 end

--- a/test/html.jl
+++ b/test/html.jl
@@ -1,10 +1,3 @@
-function drop_cache_info(html::AbstractString)
-    n = PlutoStaticHTML.n_cache_lines()
-    sep = '\n'
-    lines = split(html, sep)
-    return lines[1:end-n]
-end
-
 @testset "html" begin
     html = "<b>foo</b>"
     block = PlutoStaticHTML.code_block(html)
@@ -17,7 +10,7 @@ end
         Cell("""im_file(ext) = joinpath(PKGDIR, "test", "im", "im.\$ext")"""),
         Cell("""load(im_file("png"))""")
     ])
-    html = drop_cache_info(notebook2html!(notebook))
+    html = notebook2html!(notebook)
     lines = split(html, '\n')
 
     @test contains(lines[1], "1 + 1")

--- a/test/html.jl
+++ b/test/html.jl
@@ -10,7 +10,7 @@
         Cell("""im_file(ext) = joinpath(PKGDIR, "test", "im", "im.\$ext")"""),
         Cell("""load(im_file("png"))""")
     ])
-    html = notebook2html!(notebook)
+    html = notebook2html_helper(notebook)
     lines = split(html, '\n')
 
     @test contains(lines[1], "1 + 1")
@@ -21,7 +21,7 @@
     notebook = Notebook([
         Cell("md\"This is **markdown**\"")
     ])
-    html = notebook2html!(notebook)
+    html = notebook2html_helper(notebook)
     lines = split(html, '\n')
     @test contains(lines[2], "<strong>")
 
@@ -30,7 +30,7 @@
         Cell("""["pluto", "tree", "object"]"""),
         Cell("""[1, (2, (3, 4))]""")
     ])
-    html = notebook2html!(notebook)
+    html = notebook2html_helper(notebook)
     lines = split(html, '\n')
     @test contains(lines[2], "(\"pluto\", \"tree\", \"object\")")
     @test contains(lines[2], "<pre")
@@ -49,22 +49,23 @@
             ),
         Cell("B(1, A())")
     ])
-    html = notebook2html!(notebook)
+    html = notebook2html_helper(notebook)
     lines = split(html, '\n')
     @test contains(lines[end-1], "B(1, A())")
 
     notebook = Notebook([
         Cell("md\"my text\"")
     ])
-    html = notebook2html!(notebook; hide_md_code=true)
+    html = notebook2html_helper(notebook, HTMLOptions(; hide_md_code=true))
     lines = split(html, '\n')
     @test lines[1] == ""
 
-    html = notebook2html!(notebook; hide_md_code=false)
+    html = notebook2html_helper(notebook, HTMLOptions(; hide_md_code=false))
     lines = split(html, '\n')
     @test lines[1] != ""
 
-    html = notebook2html!(notebook; hide_md_code=false, hide_code=true)
+    opts = HTMLOptions(; hide_md_code=false, hide_code=true)
+    html = notebook2html_helper(notebook, opts)
     lines = split(html, '\n')
     @test lines[1] == ""
 end
@@ -87,7 +88,7 @@ end
     c2 = Cell("c = 600 + 3")
     PlutoStaticHTML._append_cell!(notebook, [c1, c2])
     c3 = Cell("d = 600 + 4")
-    html = notebook2html!(notebook; append_cells=[c3])
+    html = notebook2html_helper(notebook; append_cells=[c3])
     for i in 1:4
         @test contains(html, "60$i")
     end

--- a/test/html.jl
+++ b/test/html.jl
@@ -1,3 +1,10 @@
+function drop_cache_info(html::AbstractString)
+    n = PlutoStaticHTML.n_cache_lines()
+    sep = '\n'
+    lines = split(html, sep)
+    return lines[1:end-n]
+end
+
 @testset "html" begin
     html = "<b>foo</b>"
     block = PlutoStaticHTML.code_block(html)
@@ -10,7 +17,7 @@
         Cell("""im_file(ext) = joinpath(PKGDIR, "test", "im", "im.\$ext")"""),
         Cell("""load(im_file("png"))""")
     ])
-    html = notebook2html!(notebook)
+    html = drop_cache_info(notebook2html!(notebook))
     lines = split(html, '\n')
 
     @test contains(lines[1], "1 + 1")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,11 +27,20 @@ function pluto_notebook_content(code)
         """
 end
 
+function drop_cache_info(html::AbstractString)
+    n = PlutoStaticHTML.n_cache_lines()
+    sep = '\n'
+    lines = split(html, sep)
+    return join(lines[n:end], sep)
+end
+
 function notebook2html!(notebook::Notebook; append_cells=Cell[], kwargs...)
     session = ServerSession()
     PlutoStaticHTML._append_cell!(notebook, append_cells)
     run_notebook!(notebook, session)
-    return notebook2html(notebook; kwargs...)
+    html = notebook2html(notebook; kwargs...)
+    has_cache = contains(html, PlutoStaticHTML.CACHE_IDENTIFIER)
+    return has_cache ? drop_cache_info(html) : html
 end
 
 include("context.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,11 +34,15 @@ function drop_cache_info(html::AbstractString)
     return join(lines[n:end], sep)
 end
 
-function notebook2html!(notebook::Notebook; append_cells=Cell[], kwargs...)
+function notebook2html_helper(
+        notebook::Notebook,
+        opts=HTMLOptions();
+        append_cells=Cell[]
+    )
     session = ServerSession()
     PlutoStaticHTML._append_cell!(notebook, append_cells)
     run_notebook!(notebook, session)
-    html = notebook2html(notebook; kwargs...)
+    html = notebook2html(notebook, opts)
     has_cache = contains(html, PlutoStaticHTML.CACHE_IDENTIFIER)
     return has_cache ? drop_cache_info(html) : html
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,5 +35,6 @@ function notebook2html!(notebook::Notebook; append_cells=Cell[], kwargs...)
 end
 
 include("context.jl")
+include("cache.jl")
 include("html.jl")
 include("build.jl")


### PR DESCRIPTION
Works towards #26 by adding a "state" to each output HTML.

This PR also refactors the keyword argument mess that used to exist around `notebook2html`. Now, the options can be passed via the `HTMLOptions` struct.