### PR TITLE
Allow passing of `Pluto.CompilerOptions`

### DIFF
--- a/src/PlutoStaticHTML.jl
+++ b/src/PlutoStaticHTML.jl
@@ -10,6 +10,7 @@ using Pkg:
 using Pluto:
     Cell,
     CellOutput,
+    Configuration.CompilerOptions,
     Notebook,
     PkgCompat.dependencies,
     PlutoRunner,

--- a/src/build.jl
+++ b/src/build.jl
@@ -154,7 +154,9 @@ function parallel_build(
         else
             @info "Starting evaluation of Pluto notebook $in_file"
             tmp_path = _tmp_copy(in_path)
-            notebook = SessionActions.open(session, tmp_path; run_async=true)
+            compiler_options = htops.compiler_options
+            run_async = true
+            notebook = SessionActions.open(session, tmp_path; compiler_options, run_async)
             return notebook
         end
     end

--- a/src/build.jl
+++ b/src/build.jl
@@ -154,7 +154,7 @@ function parallel_build(
         else
             @info "Starting evaluation of Pluto notebook $in_file"
             tmp_path = _tmp_copy(in_path)
-            compiler_options = htops.compiler_options
+            compiler_options = hopts.compiler_options
             run_async = true
             notebook = SessionActions.open(session, tmp_path; compiler_options, run_async)
             return notebook

--- a/src/html.jl
+++ b/src/html.jl
@@ -321,6 +321,7 @@ end
     ) -> Notebook
 
 Return the notebook at `path` while ensuring that the file at `path` will not be modified.
+This method only loads the notebook; it doesn't evaluate cells.
 """
 function _load_notebook(
         path::AbstractString;

--- a/test/build.jl
+++ b/test/build.jl
@@ -15,9 +15,7 @@
         end
         parallel_build(BuildOptions(dir))
 
-        @show readdir(dir)
         html_file = joinpath(dir, "file1.html")
-        @show read(html_file, String) |> print
         @test contains(read(html_file, String), "3001")
 
         html_file = joinpath(dir, "file2.html")


### PR DESCRIPTION
This is nice for things like custom system images.