### PR TITLE
Allow avoiding recompilation

### DIFF
--- a/src/PlutoStaticHTML.jl
+++ b/src/PlutoStaticHTML.jl
@@ -11,8 +11,10 @@ using Pluto:
     Cell,
     CellOutput,
     Configuration.CompilerOptions,
+    Configuration.EvaluationOptions,
     Notebook,
     PkgCompat.dependencies,
+    Pluto,
     PlutoRunner,
     ServerSession,
     SessionActions,
@@ -31,7 +33,7 @@ include("cache.jl")
 include("html.jl")
 include("build.jl")
 
-export HTMLOptions, notebook2html, run_notebook
+export HTMLOptions, notebook2html, run_notebook!
 export BuildOptions, parallel_build
 
 end # module

--- a/src/PlutoStaticHTML.jl
+++ b/src/PlutoStaticHTML.jl
@@ -11,7 +11,6 @@ using Pluto:
     Cell,
     CellOutput,
     Configuration.CompilerOptions,
-    Configuration.EvaluationOptions,
     Notebook,
     PkgCompat.dependencies,
     Pluto,

--- a/src/build.jl
+++ b/src/build.jl
@@ -36,7 +36,7 @@ Options for `parallel_build`:
     The benefit of different processes is that things are more independent of each other.
     Unfortunately, the drawback is that compilation has to happen for each process.
     By setting this option to `false`, all notebooks are built sequentially in the same process which avoids recompilation.
-    This is likely more quick in situations where there are few threads available.
+    This is likely quicker in situations where there are few threads available such as GitHub Runners depending on the notebook contents.
 """
 struct BuildOptions
     dir::String
@@ -166,14 +166,14 @@ function parallel_build(
             tmp_path = _tmp_copy(in_path)
             compiler_options = hopts.compiler_options
             if bopts.use_distributed
+                run_async = true
+                notebook = SessionActions.open(session, tmp_path; compiler_options, run_async)
+                return notebook
+            else
                 notebook = _load_notebook(tmp_path; compiler_options)
                 options = Pluto.Configuration.from_flat_kwargs(; workspace_use_distributed=false)
                 session.options = options
                 run_notebook!(notebook, session; run_async=false)
-                return notebook
-            else
-                run_async = true
-                notebook = SessionActions.open(session, tmp_path; compiler_options, run_async)
                 return notebook
             end
         end

--- a/src/build.jl
+++ b/src/build.jl
@@ -155,8 +155,12 @@ function parallel_build(
             @info "Starting evaluation of Pluto notebook $in_file"
             tmp_path = _tmp_copy(in_path)
             compiler_options = hopts.compiler_options
-            run_async = true
-            notebook = SessionActions.open(session, tmp_path; compiler_options, run_async)
+            run_async = false
+            notebook = _load_notebook(tmp_path; compiler_options)
+            options = Pluto.Configuration.from_flat_kwargs(; workspace_use_distributed=false)
+            session.options = options
+            @time run_notebook!(notebook, session)
+            @info "for $in_file"
             return notebook
         end
     end

--- a/src/html.jl
+++ b/src/html.jl
@@ -269,7 +269,7 @@ function _append_cell!(notebook::Notebook, cells::AbstractVector{Cell})
     return notebook
 end
 
-function run_notebook(notebook, session; run_async=false)
+function run_notebook!(notebook, session; run_async=false)
     cells = [last(e) for e in notebook.cells_dict]
     update_save_run!(session, notebook, cells; run_async)
     return nothing
@@ -303,6 +303,7 @@ function notebook2html(notebook::Notebook, path, opts::HTMLOptions=HTMLOptions()
 end
 
 const TMP_COPY_PREFIX = "_tmp_"
+
 """
     _tmp_copy(path::AbstractString)
 
@@ -360,7 +361,7 @@ function notebook2html(
     )::String
     notebook = _load_notebook(path)
     PlutoStaticHTML._append_cell!(notebook, append_cells)
-    run_notebook(notebook, session; run_async=false)
+    run_notebook!(notebook, session; run_async=false)
     html = notebook2html(notebook, path, opts)
     return html
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,7 @@ function notebook2html_helper(
     )
     session = ServerSession()
     PlutoStaticHTML._append_cell!(notebook, append_cells)
-    run_notebook(notebook, session)
+    run_notebook!(notebook, session)
     path = nothing
     html = notebook2html(notebook, path, opts)
 


### PR DESCRIPTION
This PR adds a keyword argument `use_distributed` which can be disabled to disable parallel processing. Instead, everything will be executed in the same process which avoids recompiling for each process. This can be more quick in systems with few threads such as GitHub Runners depending on the workload.

Also, rename `run_notebook` to `run_notebook!` because it mutates the first argument.