### PR TITLE
Add `PlutoUI` to example notebook

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -44,7 +44,7 @@ if !("DISABLE_NOTEBOOK_BUILD" in keys(ENV))
 end
 
 function write_dynamic_notebook()
-    html = __build()
+    html = PlutoStaticHTML.__build()
     md = """
         # Dynamic
 

--- a/docs/src/dynamic.jl
+++ b/docs/src/dynamic.jl
@@ -21,12 +21,12 @@ The functionality shown at this page is highly experimental and may be dropped f
 
 # ╔═╡ 93635e2a-755e-11ec-3dae-c77f892d6c22
 begin
-	# Examples at https://juliapluto.github.io/sample-notebook-previews/PlutoUI.jl.html.
-	# using Pkg
-	# Pkg.activate(; temp=true)
-	# Pkg.add("PlutoUI")
-	# Pkg.instantiate()
-	# using PlutoUI
+    # Examples at https://juliapluto.github.io/sample-notebook-previews/PlutoUI.jl.html.
+    # using Pkg
+    # Pkg.activate(; temp=true)
+    # Pkg.add("PlutoUI")
+    # Pkg.instantiate()
+    using PlutoUI
 end
 
 # ╔═╡ 0000000a-7036-4bc5-b7b4-4e701eb653f7

--- a/docs/src/dynamic.jl
+++ b/docs/src/dynamic.jl
@@ -22,10 +22,9 @@ The functionality shown at this page is highly experimental and may be dropped f
 # ╔═╡ 93635e2a-755e-11ec-3dae-c77f892d6c22
 begin
     # Examples at https://juliapluto.github.io/sample-notebook-previews/PlutoUI.jl.html.
-    # using Pkg
-    # Pkg.activate(; temp=true)
-    # Pkg.add("PlutoUI")
-    # Pkg.instantiate()
+    using Pkg
+    Pkg.activate(; temp=true)
+    Pkg.add("PlutoUI")
     using PlutoUI
 end
 

--- a/src/build.jl
+++ b/src/build.jl
@@ -39,6 +39,7 @@ Options for `parallel_build`:
     Unfortunately, the drawback is that compilation has to happen for each process.
     By setting this option to `false`, all notebooks are built sequentially in the same process which avoids recompilation.
     This is likely quicker in situations where there are few threads available such as GitHub Runners depending on the notebook contents.
+    Beware that `use_distributed=false` will not work with Pluto's built-in package manager.
 - `store_binds::Bool=false`:
     Store outputs for all possible combinations of bind values.
     *Highly experimental feature which may be removed at any time.*
@@ -180,6 +181,7 @@ function parallel_build(
                 nb = _load_notebook(in_path; compiler_options)
                 options = Pluto.Configuration.from_flat_kwargs(; workspace_use_distributed=false)
                 session.options = options
+                session.options.server.disable_writing_notebook_files = true
                 run_notebook!(nb, session)
                 if bopts.store_binds
                     nbo = _run_dynamic!(nb, session)

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -325,7 +325,7 @@ function __build()
     dir = joinpath(pkgdir(PlutoStaticHTML), "docs", "src")
     file = "dynamic.jl"
 
-    bopts = BuildOptions(dir; store_binds=true, use_distributed=false)
+    bopts = BuildOptions(dir; store_binds=true, use_distributed=true)
     hopts = HTMLOptions(; output_class="documenter-example-output")
     htmls = parallel_build(bopts, [file], hopts)
     html = only(htmls)

--- a/src/html.jl
+++ b/src/html.jl
@@ -139,7 +139,7 @@ function _output2html(cell::Cell, T::IMAGEMIME, hopts)
 end
 
 function _output2html(cell::Cell, ::MIME"application/vnd.pluto.stacktrace+object", hopts)
-    return error(body)
+    return error(cell.output.body)
 end
 
 function _tr_wrap(elements::Vector)

--- a/test/html.jl
+++ b/test/html.jl
@@ -119,3 +119,14 @@ end
     @test_throws Exception run_notebook!(nb, session)
 end
 
+# Test whether `run_notebook!` can also handle loading of packages when `use_distributed=false`.
+# https://github.com/rikhuijzer/PlutoStaticHTML.jl/issues/42
+@testset "run_notebook!_pkg" begin
+    session = ServerSession()
+    options = Pluto.Configuration.from_flat_kwargs(; workspace_use_distributed=false)
+    session.options = options
+
+    nb = Notebook([Cell("using PlutoUI")])
+    run_notebook!(nb, session)
+
+end

--- a/test/html.jl
+++ b/test/html.jl
@@ -118,15 +118,3 @@ end
     nb = Notebook([Cell("@assert false")])
     @test_throws Exception run_notebook!(nb, session)
 end
-
-# Test whether `run_notebook!` can also handle loading of packages when `use_distributed=false`.
-# https://github.com/rikhuijzer/PlutoStaticHTML.jl/issues/42
-@testset "run_notebook!_pkg" begin
-    session = ServerSession()
-    options = Pluto.Configuration.from_flat_kwargs(; workspace_use_distributed=false)
-    session.options = options
-
-    nb = Notebook([Cell("using PlutoUI")])
-    run_notebook!(nb, session)
-
-end


### PR DESCRIPTION
Sort of closes #42. I guess `use_distributed=false` is and will remain unreliable for managing packages. I wasn't able to figure out the cause.