### PR TITLE
Fix `run_notebook!`

### DIFF
--- a/src/PlutoStaticHTML.jl
+++ b/src/PlutoStaticHTML.jl
@@ -35,7 +35,7 @@ include("cache.jl")
 include("html.jl")
 include("build.jl")
 
-export HTMLOptions, notebook2html, run_notebook!
+export HTMLOptions, notebook2html
 export franklin_output, html_output
 export BuildOptions, parallel_build
 export cell2uuid

--- a/src/build.jl
+++ b/src/build.jl
@@ -183,6 +183,8 @@ function _outcome2text(session, nb::Notebook, in_path, bopts, hopts)::String
         sleep(0.1)
     end
 
+    _throw_if_error(nb)
+
     # Grab output before changing binds via `_run_dynamic!`.
     # Otherwise, the outputs look wrong when opening a page for the first time.
     html = notebook2html(nb, in_path, hopts)

--- a/src/build.jl
+++ b/src/build.jl
@@ -227,18 +227,15 @@ function parallel_build(
             return previous
         else
             @info "Starting evaluation of Pluto notebook $in_file"
-            compiler_options = hopts.compiler_options
             if bopts.use_distributed
-                tmp_path = _tmp_copy(in_path)
-                nb = SessionActions.open(session, tmp_path; compiler_options, run_async=true)
-                return nb
+                run_async = true
             else
-                nb = _load_notebook(in_path; compiler_options)
+                run_async = false
+                # `use_distributed` means mostly "whether to run in a new process".
                 session.options.evaluation.workspace_use_distributed = false
-                session.options.server.disable_writing_notebook_files = true
-                run_notebook!(nb, session)
-                return nb
             end
+            nb = run_notebook!(in_path, session; hopts, run_async)
+            return nb
         end
     end
 

--- a/src/html.jl
+++ b/src/html.jl
@@ -272,20 +272,6 @@ function _var(cell::Cell)::Symbol
     end
 end
 
-"When this cell is added to a notebook, it will disable Pluto's tree viewer."
-function disable_tree_viewer_cell()::Cell
-    code = """
-        begin
-            if false
-                # To ensure that this cell runs first.
-                import Pkg
-            end
-            PlutoRunner.use_tree_viewer_for_struct(x) = true
-        end
-        """
-    return Cell(code)
-end
-
 function _output2html(cell::Cell, ::MIME"application/vnd.pluto.tree+object", hopts)
     body = cell.output.body
     T = symbol2type(body[:type])

--- a/test/html.jl
+++ b/test/html.jl
@@ -1,18 +1,3 @@
-@testset "tmp_copy" begin
-    dir = mktempdir()
-    cd(dir) do
-        path = joinpath(dir, "notebook.jl")
-        touch(path)
-        @test isfile(path)
-        cp_path = PlutoStaticHTML._tmp_copy(path)
-        @test isfile(cp_path)
-        # Ensure that `@__DIR__` can be used.
-        # https://github.com/rikhuijzer/PlutoStaticHTML.jl/issues/31
-        @test dirname(cp_path) == dir
-        @test basename(cp_path) == "_tmp_notebook.jl"
-    end
-end
-
 @testset "contains" begin
     html = "<b>foo</b>"
     block = PlutoStaticHTML.code_block(html)
@@ -45,8 +30,7 @@ end
         Cell("""["pluto", "tree", "object"]"""),
         Cell("""[1, (2, (3, 4))]""")
     ])
-    append_cells = [PlutoStaticHTML.disable_tree_viewer_cell()]
-    html = notebook2html_helper(notebook; append_cells)
+    html = notebook2html_helper(notebook)
     lines = split(html, '\n')
     @test contains(lines[2], "(\"pluto\", \"tree\", \"object\")")
     @test contains(lines[2], "<pre")
@@ -114,10 +98,10 @@ end
     session = ServerSession()
 
     nb = Notebook([Cell("@assert true")])
-    run_notebook!(nb, session)
+    PlutoStaticHTML.run_notebook!(nb, session)
 
     nb = Notebook([Cell("@assert false")])
-    @test_throws Exception run_notebook!(nb, session)
+    @test_throws Exception PlutoStaticHTML.run_notebook!(nb, session)
 end
 
 @testset "_var" begin
@@ -128,7 +112,7 @@ end
         Cell("b = a + 1")
     ])
     # This is required for _var.
-    run_notebook!(nb, session)
+    PlutoStaticHTML.run_notebook!(nb, session)
 
     @test PlutoStaticHTML._var(nb.cells[1]) == :a
     @test PlutoStaticHTML._var(nb.cells[2]) == :b

--- a/test/html.jl
+++ b/test/html.jl
@@ -95,13 +95,13 @@ end
 end
 
 @testset "run_notebook!_errors" begin
-    session = ServerSession()
-
-    nb = Notebook([Cell("@assert true")])
-    PlutoStaticHTML.run_notebook!(nb, session)
-
-    nb = Notebook([Cell("@assert false")])
-    @test_throws Exception PlutoStaticHTML.run_notebook!(nb, session)
+    mktempdir() do dir
+        text = pluto_notebook_content("@assert false")
+        path = joinpath(dir, "notebook.jl")
+        write(path, text)
+        session = ServerSession()
+        @test_throws Exception PlutoStaticHTML.run_notebook!(path, session)
+    end
 end
 
 @testset "_var" begin

--- a/test/html.jl
+++ b/test/html.jl
@@ -111,8 +111,8 @@ end
         Cell("a = 1"),
         Cell("b = a + 1")
     ])
-    # This is required for _var.
-    PlutoStaticHTML.run_notebook!(nb, session)
+    # Running the notebook is required for _var.
+    notebook2html_helper(nb)
 
     @test PlutoStaticHTML._var(nb.cells[1]) == :a
     @test PlutoStaticHTML._var(nb.cells[2]) == :b

--- a/test/html.jl
+++ b/test/html.jl
@@ -45,7 +45,8 @@ end
         Cell("""["pluto", "tree", "object"]"""),
         Cell("""[1, (2, (3, 4))]""")
     ])
-    html = notebook2html_helper(notebook)
+    append_cells = [PlutoStaticHTML.disable_tree_viewer_cell()]
+    html = notebook2html_helper(notebook; append_cells)
     lines = split(html, '\n')
     @test contains(lines[2], "(\"pluto\", \"tree\", \"object\")")
     @test contains(lines[2], "<pre")

--- a/test/preliminaries.jl
+++ b/test/preliminaries.jl
@@ -39,17 +39,20 @@ function drop_begin_end(html::AbstractString)
     return join(lines[2:end-1], sep)
 end
 
+"Helper function to simply pass a `nb::Notebook` and run it."
 function notebook2html_helper(
-        notebook::Notebook,
+        nb::Notebook,
         opts=HTMLOptions();
         append_cells=Cell[]
     )
     session = ServerSession()
-    PlutoStaticHTML._append_cell!(notebook, append_cells)
-    run_notebook!(notebook, session)
+    PlutoStaticHTML._append_cell!(nb, append_cells)
+    session.notebooks[nb.notebook_id] = nb
+    Pluto.update_save_run!(session, nb, nb.cells)
     path = nothing
-    html = notebook2html(notebook, path, opts)
+    html = notebook2html(nb, path, opts)
 
+    # Remove the caching information because it's not important for most tests.
     has_cache = contains(html, PlutoStaticHTML.STATE_IDENTIFIER)
     without_cache = has_cache ? drop_cache_info(html) : html
 


### PR DESCRIPTION
The implementation of `run_notebook!` is currently wrong. Evaluation cells inside Pluto is quite an involved process, so using `SessionActions.open` is a must.

However, that API isn't capable enough yet, so I'll first have to open a PR at their side. `open` can only open `path::AbstractString` and not `nb::Notebook`. This last functionality is necessary in case one want to modify the notebook a bit before letting Pluto evaluate it