### PR TITLE
Add `documenter_output`

### DIFF
--- a/src/PlutoStaticHTML.jl
+++ b/src/PlutoStaticHTML.jl
@@ -36,7 +36,7 @@ include("html.jl")
 include("build.jl")
 
 export HTMLOptions, notebook2html
-export franklin_output, html_output
+export documenter_output, franklin_output, html_output
 export BuildOptions, parallel_build
 export cell2uuid
 


### PR DESCRIPTION
Now, PlutoStaticHTML.jl can generate Markdown files which can be read by Documenter.jl. Also, this PR contains some styling to make things look better.

Generating Documenter.jl output is as easy as putting the following in `docs/make.jl`:

```julia
using MyPackage
using Documenter
using PlutoStaticHTML

"""
Run all Pluto notebooks (".jl" files) in `tutorials_dir` and write output to Markdown files.
"""
function build_tutorials()
    println("Building tutorials")
    dir = joinpath(pkgdir(MyPackage), "docs", "src", "notebooks")
    # Evaluate notebooks in the same process to avoid having to recompile from scratch each time.
    # This is similar to how Documenter and Franklin evaluate code.
    # Note that things like method overrides may leak between notebooks!
    use_distributed = false
    output_format = documenter_output
    bopts = BuildOptions(dir; use_distributed, output_format)
    parallel_build(bopts)
    return nothing
end

build_tutorials()

pages = [
    "Home" => "index.md",
    "SMOTE" => "notebooks/smote.md"
]

makedocs(;
    modules=[MyPackage],
    sitename="MyPackage.jl",
    format=Documenter.HTML(;
        canonical="https://rikhuijzer.github.io/MyPackage.jl",
        # Using MathJax3 since Pluto uses that engine too.
        mathengine=Documenter.MathJax3(),
        prettyurls=get(ENV, "CI", "false") == "true",
    ),
    pages
)
```

where, in this example, `dir` contains one notebook with the filename `smote.jl`. PlutoStaticHTML.jl creates the `smote.md` file.

In a few days or so, there will be an example implementation at [TuringGLM.jl](https://github.com/TuringLang/TuringGLM.jl).