### PR TITLE
Disable Pluto's tree printing

### DIFF
--- a/src/PlutoStaticHTML.jl
+++ b/src/PlutoStaticHTML.jl
@@ -3,6 +3,7 @@ module PlutoStaticHTML
 import Base:
     show,
     string
+import Pluto: WorkspaceManager
 
 using Base64: base64encode
 using Pkg:

--- a/src/PlutoStaticHTML.jl
+++ b/src/PlutoStaticHTML.jl
@@ -3,7 +3,9 @@ module PlutoStaticHTML
 import Base:
     show,
     string
-import Pluto: WorkspaceManager
+import Pluto:
+    PlutoRunner,
+    WorkspaceManager
 
 using Base64: base64encode
 using Pkg:

--- a/src/html.jl
+++ b/src/html.jl
@@ -92,37 +92,6 @@ struct HTMLOptions
     end
 end
 
-# Override the full method because allmimes was replaced by the compiler.
-function PlutoRunner.show_richest(io::IO, @nospecialize(x))::Tuple{<:Any,MIME}
-    nonplutomimes = filter(m -> !occursin("pluto.tree", string(m)), PlutoRunner.allmimes)
-    # ugly code to fix an ugly performance problem
-    local mime = nothing
-    for m in nonplutomimes
-        if PlutoRunner.pluto_showable(m, x)
-            mime = m
-            break
-        end
-    end
-
-    if mime ∈ PlutoRunner.imagemimes
-        show(io, mime, x)
-        nothing, mime
-    elseif mime isa MIME"application/vnd.pluto.table+object"
-        table_data(x, IOContext(io, :compact => true)), mime
-    elseif mime isa MIME"text/latex"
-        # Some reprs include $ at the start and end.
-        # We strip those, since Markdown.LaTeX should contain the math content.
-        # (It will be rendered by MathJax, which is math-first, not text-first.)
-        texed = repr(mime, x)
-        Markdown.html(io, Markdown.LaTeX(strip(texed, ('$', '\n', ' '))))
-        nothing, MIME"text/html"()
-    else
-        # the classic:
-        show(io, mime, x)
-        nothing, mime
-    end
-end
-
 # Override the preamble to disable Pluto's pretty printing.
 WorkspaceManager.process_preamble() = quote
     # Copy pasted from Pluto's source.
@@ -134,7 +103,7 @@ WorkspaceManager.process_preamble() = quote
     ENV["JULIA_REVISE_WORKER_ONLY"] = "1"
 
     # Extra overrides.
-    # We need to override it twice for some reason.
+    # Override the full method because allmimes was replaced by the compiler.
     function PlutoRunner.show_richest(io::IO, @nospecialize(x))::Tuple{<:Any,MIME}
         nonplutomimes = filter(m -> !occursin("pluto.tree", string(m)), PlutoRunner.allmimes)
         # ugly code to fix an ugly performance problem
@@ -150,7 +119,7 @@ WorkspaceManager.process_preamble() = quote
             show(io, mime, x)
             nothing, mime
         elseif mime isa MIME"application/vnd.pluto.table+object"
-            table_data(x, IOContext(io, :compact => true)), mime
+            PlutoRunner.table_data(x, IOContext(io, :compact => true)), mime
         elseif mime isa MIME"text/latex"
             # Some reprs include $ at the start and end.
             # We strip those, since Markdown.LaTeX should contain the math content.

--- a/src/html.jl
+++ b/src/html.jl
@@ -135,6 +135,8 @@ WorkspaceManager.process_preamble() = quote
     end
 end
 
+# Yes. Two overrides are necessary. This one is used during testing.
+# Override the full method because allmimes was replaced by the compiler.
 function PlutoRunner.show_richest(io::IO, @nospecialize(x))::Tuple{<:Any,MIME}
     nonplutomimes = filter(m -> !occursin("pluto.tree", string(m)), PlutoRunner.allmimes)
     # ugly code to fix an ugly performance problem

--- a/test/html.jl
+++ b/test/html.jl
@@ -36,7 +36,6 @@
     @test contains(lines[2], "(\"pluto\", \"tree\", \"object\")")
     @test contains(lines[2], "<pre")
     @test contains(lines[5], "[\"pluto\", \"tree\", \"object\"]")
-
     @test contains(lines[8], "[1, (2, (3, 4))]")
     @test contains(lines[11], "(a = (1, 2), b = (3, 4))")
 

--- a/test/html.jl
+++ b/test/html.jl
@@ -35,9 +35,11 @@
     lines = split(html, '\n')
     @test contains(lines[2], "(\"pluto\", \"tree\", \"object\")")
     @test contains(lines[2], "<pre")
-    @test contains(lines[5], "[\"pluto\", \"tree\", \"object\"]")
-    @test contains(lines[8], "[1, (2, (3, 4))]")
-    @test contains(lines[11], "(a = (1, 2), b = (3, 4))")
+    @test contains(lines[6], "pluto")
+    @test contains(lines[7], "tree")
+    @test contains(lines[8], "object")
+    @test contains(lines[11], "2-element Vector")
+    @test contains(lines[16], "(a = (1, 2), b = (3, 4))")
 
     notebook = Notebook([
         Cell("struct A end"),
@@ -119,6 +121,7 @@ end
 end
 
 @testset "benchmark-hack" begin
+    # Related to https://github.com/fonsp/Pluto.jl/issues/1664
     nb = Notebook([
         Cell("using BenchmarkTools"),
         Cell("@benchmark sum(x)"),

--- a/test/html.jl
+++ b/test/html.jl
@@ -130,3 +130,4 @@ end
     html, nb = notebook2html_helper(nb)
     @test contains(html, "3")
 end
+

--- a/test/html.jl
+++ b/test/html.jl
@@ -38,6 +38,7 @@
     @test contains(lines[5], "[\"pluto\", \"tree\", \"object\"]")
 
     @test contains(lines[8], "[1, (2, (3, 4))]")
+    @test contains(lines[11], "(a = (1, 2), b = (3, 4))")
 
     notebook = Notebook([
         Cell("struct A end"),

--- a/test/html.jl
+++ b/test/html.jl
@@ -10,7 +10,7 @@
         Cell("""im_file(ext) = joinpath(PKGDIR, "test", "im", "im.\$ext")"""),
         Cell("""load(im_file("png"))""")
     ])
-    html = notebook2html_helper(notebook)
+    html, nb = notebook2html_helper(notebook)
     lines = split(html, '\n')
 
     @test contains(lines[1], "1 + 1")
@@ -21,16 +21,17 @@
     notebook = Notebook([
         Cell("md\"This is **markdown**\"")
     ])
-    html = notebook2html_helper(notebook)
+    html, nb = notebook2html_helper(notebook)
     lines = split(html, '\n')
     @test contains(lines[2], "<strong>")
 
     notebook = Notebook([
         Cell("""("pluto", "tree", "object")"""),
         Cell("""["pluto", "tree", "object"]"""),
-        Cell("""[1, (2, (3, 4))]""")
+        Cell("""[1, (2, (3, 4))]"""),
+        Cell("(; a=(1, 2), b=(3, 4))")
     ])
-    html = notebook2html_helper(notebook)
+    html, nb = notebook2html_helper(notebook);
     lines = split(html, '\n')
     @test contains(lines[2], "(\"pluto\", \"tree\", \"object\")")
     @test contains(lines[2], "<pre")
@@ -49,23 +50,23 @@
             ),
         Cell("B(1, A())")
     ])
-    html = notebook2html_helper(notebook)
+    html, nb = notebook2html_helper(notebook)
     lines = split(html, '\n')
     @test contains(lines[end-1], "B(1, A())")
 
     notebook = Notebook([
         Cell("md\"my text\"")
     ])
-    html = notebook2html_helper(notebook, HTMLOptions(; hide_md_code=true))
+    html, nb = notebook2html_helper(notebook, HTMLOptions(; hide_md_code=true))
     lines = split(html, '\n')
     @test lines[1] == ""
 
-    html = notebook2html_helper(notebook, HTMLOptions(; hide_md_code=false))
+    html, nb = notebook2html_helper(notebook, HTMLOptions(; hide_md_code=false))
     lines = split(html, '\n')
     @test lines[1] != ""
 
     opts = HTMLOptions(; hide_md_code=false, hide_code=true)
-    html = notebook2html_helper(notebook, opts)
+    html, nb = notebook2html_helper(notebook, opts);
     lines = split(html, '\n')
     @test lines[1] == ""
 end
@@ -88,7 +89,7 @@ end
     c2 = Cell("c = 600 + 3")
     PlutoStaticHTML._append_cell!(notebook, [c1, c2])
     c3 = Cell("d = 600 + 4")
-    html = notebook2html_helper(notebook; append_cells=[c3])
+    html, nb = notebook2html_helper(notebook; append_cells=[c3])
     for i in 1:4
         @test contains(html, "60$i")
     end
@@ -112,7 +113,7 @@ end
     nb = Notebook([
         Cell(text),
     ])
-    html = notebook2html_helper(nb)
+    html, nb = notebook2html_helper(nb)
 
     @test !contains(html, "pluto-docs-binding")
 end
@@ -123,6 +124,6 @@ end
         Cell("@benchmark sum(x)"),
         Cell("x = [1, 2]")
     ])
-    html = notebook2html_helper(nb)
+    html, nb = notebook2html_helper(nb)
     @test contains(html, "3")
 end

--- a/test/preliminaries.jl
+++ b/test/preliminaries.jl
@@ -3,7 +3,8 @@ using Pluto:
     Cell,
     Notebook,
     Pluto,
-    ServerSession
+    ServerSession,
+    SessionActions
 using Test
 
 const PKGDIR = string(pkgdir(PlutoStaticHTML))::String
@@ -59,6 +60,6 @@ function notebook2html_helper(
     has_cache = contains(html, PlutoStaticHTML.STATE_IDENTIFIER)
     without_cache = has_cache ? drop_cache_info(without_begin_end) : html
 
-    return without_cache
+    return (without_cache, nb)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,11 @@
 include("preliminaries.jl")
 
-# include("context.jl")
-# include("cache.jl")
+include("context.jl")
+include("cache.jl")
 
 @testset "html" begin
     include("html.jl")
 end
 
-# include("build.jl")
+include("build.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,11 @@
 include("preliminaries.jl")
 
-include("context.jl")
-include("cache.jl")
+# include("context.jl")
+# include("cache.jl")
 
 @testset "html" begin
     include("html.jl")
 end
 
-include("build.jl")
+# include("build.jl")
 


### PR DESCRIPTION
Fixes #53.

The trees used to be very complex to unpack, so with this PR they are not generated in the first place. This has fixed an issue where a DataFrame contained tuple elements.