### PR TITLE
Improve error futher

### DIFF
--- a/src/html.jl
+++ b/src/html.jl
@@ -308,6 +308,11 @@ function _retry_run(session, nb, cell::Cell)
     Pluto.update_save_run!(session, nb, [cell])
 end
 
+"Indent each line by two spaces."
+function _indent(s::AbstractString)::String
+    return replace(s, '\n' => "\n  ")::String
+end
+
 function _throw_if_error(session::ServerSession, nb::Notebook)
     cells = [nb.cells_dict[cell_uuid] for cell_uuid in nb.cell_order]
     for cell in cells
@@ -326,13 +331,21 @@ function _throw_if_error(session::ServerSession, nb::Notebook)
             io = IOBuffer()
             ioc = IOContext(io, :color => Base.get_have_color())
             showerror(ioc, val)
-            error_text = String(take!(io))
+            error_text = _indent(String(take!(io)))
+            code = _indent(cell.code)
+            filename = _indent(nb.path)
             msg = """
-                Execution of the notebook failed.
+                Execution of notebook failed.
                 Does the notebook show any errors when opening it in Pluto?
 
-                Details:
-                $error_text
+                Notebook:
+                  $filename
+
+                Code:
+                  $code
+
+                Error:
+                  $error_text
                 """
             error(msg)
         end

--- a/test/html.jl
+++ b/test/html.jl
@@ -104,6 +104,8 @@ end
         @test err isa Exception
         msg = sprint(showerror, err)
         @test contains(msg, "notebook failed")
+        @test contains(msg, "notebook.jl")
+        @test contains(msg, "sum(1, :b)")
         @test contains(msg, "Closest candidates are")
         @test contains(msg, "_foldl_impl")
     end


### PR DESCRIPTION
The error message is better since #64, but didn't show what code block in which file produced the error. This is fixed now:

```
julia> PlutoStaticHTML._throw_if_error(session, nb)
ERROR: Execution of notebook failed.
Does the notebook show any errors when opening it in Pluto?

Notebook:
  /tmp/jl_dftEwe/notebook.jl

Code:
  sum(1, :b)

Error:
  MethodError: no method matching iterate(::Symbol)
  Closest candidates are:
    iterate(::Union{LinRange, StepRangeLen}) at /nix/store/13y7yhpqlx7rkm1cyg4j4r1rp1s07nfa-julia-bin-1.7.2/share/julia/base/range.jl:826
    iterate(::Union{LinRange, StepRangeLen}, ::Integer) at /nix/store/13y7yhpqlx7rkm1cyg4j4r1rp1s07nfa-julia-bin-1.7.2/share/julia/base/range.jl:826
    iterate(::T) where T<:Union{Base.KeySet{<:Any, <:Dict}, Base.ValueIterator{<:Dict}} at /nix/store/13y7yhpqlx7rkm1cyg4j4r1rp1s07nfa-julia-bin-1.7.2/share/julia/base/dict.jl:695
    ...
  Stacktrace:
    [1] _foldl_impl
      @ ./reduce.jl:56
    [2] foldl_impl
      @ ./reduce.jl:48
    [3] mapfoldl_impl
      @ ./reduce.jl:44
    [4] #mapfoldl#244
      @ ./reduce.jl:162
    [5] mapfoldl
      @ ./reduce.jl:162
    [6] #mapreduce#248
      @ ./reduce.jl:289
    [7] mapreduce
      @ ./reduce.jl:289
    [8] #sum#251
      @ ./reduce.jl:503
    [9] sum
      @ ./reduce.jl:503
   [10] ##function_wrapped_cell#292
      @ /tmp/jl_dftEwe/notebook.jl#==#a6dda572-3f2c-11ec-0eeb-69e2323a92de:1 [inlined]
   [11] ##function_wrapped_cell#292
      @ ./none:0
[...]
```