### PR TITLE
Bump Pluto compat entry to 0.18.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,5 +11,5 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
-Pluto = "=0.18.0"
+Pluto = "=0.18.1"
 julia = "1.6"

--- a/src/html.jl
+++ b/src/html.jl
@@ -256,23 +256,6 @@ function _cell2html(cell::Cell, hopts::HTMLOptions)
         """
 end
 
-"""
-    _append_cell!(notebook::Notebook, cell::Cell)
-
-Add one `cell` to the end of the `notebook`.
-This is based on `add_remote_cell` in Pluto's `Editor.js`.
-"""
-function _append_cell!(notebook::Notebook, cell::Cell)
-    push!(notebook.cell_order, cell.cell_id)
-    notebook.cells_dict[cell.cell_id] = cell
-    return notebook
-end
-
-function _append_cell!(notebook::Notebook, cells::AbstractVector{Cell})
-    foreach(c -> _append_cell!(notebook, c), cells)
-    return notebook
-end
-
 const BEGIN_IDENTIFIER = "<!-- PlutoStaticHTML.Begin -->"
 const END_IDENTIFIER = "<!-- PlutoStaticHTML.End -->"
 
@@ -373,20 +356,14 @@ end
         path::AbstractString,
         opts::HTMLOptions=HTMLOptions();
         session=ServerSession(),
-        append_cells=Cell[],
     ) -> String
 
 Run the Pluto notebook at `path` and return the code and output as HTML.
-
-Keyword arguments:
-
-- `append_cells`: Specify one or more `Pluto.Cell`s to be appended at the end of the notebook.
 """
 function notebook2html(
         path::AbstractString,
         hopts::HTMLOptions=HTMLOptions();
-        session=ServerSession(),
-        append_cells=Cell[],
+        session=ServerSession()
     )::String
     nb = run_notebook!(path, session; run_async=false, hopts)
     html = notebook2html(nb, path, hopts)

--- a/test/html.jl
+++ b/test/html.jl
@@ -75,20 +75,6 @@ end
     end
 end
 
-@testset "append_cell" begin
-    notebook = Notebook([
-        Cell("a = 600 + 1"),
-    ])
-    c1 = Cell("b = 600 + 2")
-    c2 = Cell("c = 600 + 3")
-    PlutoStaticHTML._append_cell!(notebook, [c1, c2])
-    c3 = Cell("d = 600 + 4")
-    html, nb = notebook2html_helper(notebook; append_cells=[c3])
-    for i in 1:4
-        @test contains(html, "60$i")
-    end
-end
-
 @testset "run_notebook!_errors" begin
     mktempdir() do dir
         text = pluto_notebook_content("sum(1, :b)")

--- a/test/preliminaries.jl
+++ b/test/preliminaries.jl
@@ -42,10 +42,8 @@ end
 "Helper function to simply pass a `nb::Notebook` and run it."
 function notebook2html_helper(
         nb::Notebook,
-        opts=HTMLOptions();
-        append_cells=Cell[]
+        opts=HTMLOptions()
     )
-    PlutoStaticHTML._append_cell!(nb, append_cells)
     tmpdir = mktempdir()
     tmppath = joinpath(tmpdir, "notebook.jl")
     Pluto.save_notebook(nb, tmppath)


### PR DESCRIPTION
This also removes the `append_cell` functionality. That functionality used to be there to add build context but it turned out that it's not really possible to add a cell without changing the behavior of the notebook. In most cases, it's better to just add the cell to the notebook manually and, if needed, hide stuff via `# hideall` or some kind of conditional