### PR TITLE
Reduce running time of tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"

--- a/test/build.jl
+++ b/test/build.jl
@@ -13,7 +13,7 @@
             write(path, content)
             return file
         end
-        parallel_build(BuildOptions(dir))
+        parallel_build(BuildOptions(dir, use_distributed=false))
 
         html_file = joinpath(dir, "file1.html")
         @test contains(read(html_file, String), "3001")
@@ -30,7 +30,7 @@ end
             file = "file.jl"
             path = joinpath(dir, file)
             write(path, content)
-            parallel_build(BuildOptions(dir), [file])
+            parallel_build(BuildOptions(dir), [file], use_distributed=false)
         end
         error("Test should have failed")
     catch AssertionError

--- a/test/cache.jl
+++ b/test/cache.jl
@@ -33,6 +33,7 @@ end
 
 @testset "caching" begin
     dir = mktempdir()
+    use_distributed = false
 
     cd(dir) do
         path(name) = joinpath(dir, "$name.txt")
@@ -48,7 +49,7 @@ end
         code = pluto_notebook_content("""write("$(path('b'))", "b")""")
         write("b.jl", code)
 
-        bo = BuildOptions(dir)
+        bo = BuildOptions(dir; use_distributed)
         parallel_build(bo)
 
         # Without try_read, Pluto in another process may still have a lock on a txt file.
@@ -68,7 +69,7 @@ end
             cp(joinpath(previous_dir, "a.jl"), joinpath(dir, "a.jl"))
             cp(joinpath(previous_dir, "b.jl"), joinpath(dir, "b.jl"))
 
-            bo = BuildOptions(dir; previous_dir)
+            bo = BuildOptions(dir; use_distributed, previous_dir)
             parallel_build(bo)
 
             # a was evaluated because "a.html" was removed.
@@ -141,9 +142,9 @@ end
             """)
         write(path, code)
 
-        output_format = franklin_output
         use_distributed = false
-        bo = BuildOptions(dir; output_format, use_distributed)
+        output_format = franklin_output
+        bo = BuildOptions(dir; use_distributed, output_format)
         parallel_build(bo)
 
         output_path = joinpath(dir, "notebook.md")

--- a/test/context.jl
+++ b/test/context.jl
@@ -1,9 +1,13 @@
-@testset "context" begin
-    hopts = HTMLOptions(; append_build_context=true)
-    bopts = BuildOptions(NOTEBOOK_DIR)
-    files = ["example.jl"]
+tmpdir = mktempdir()
+content = pluto_notebook_content("""
+    # Very small package.
+    using PrecompileMacro
+    """)
+write(joinpath(tmpdir, "notebook.jl"), content)
 
-    html = only(parallel_build(bopts, files, hopts))
-    @test contains(html, r"Built with Julia 1.*")
-    @test contains(html, "CairoMakie")
-end
+hopts = HTMLOptions(; append_build_context=true)
+bopts = BuildOptions(tmpdir; use_distributed=true)
+
+html = only(parallel_build(bopts, hopts))
+@test contains(html, r"Built with Julia 1.*")
+@test contains(html, "PrecompileMacro")

--- a/test/mimeoverride.jl
+++ b/test/mimeoverride.jl
@@ -1,4 +1,3 @@
-
 notebook = Notebook([
     Cell("md\"This is **markdown**\"")
 ])
@@ -21,4 +20,3 @@ lines = split(html, '\n')
 @test contains(lines[8], "object")
 @test contains(lines[11], "2-element Vector")
 @test contains(lines[16], "(a = (1, 2), b = (3, 4))")
-

--- a/test/preliminaries.jl
+++ b/test/preliminaries.jl
@@ -6,6 +6,7 @@ using Pluto:
     ServerSession,
     SessionActions
 using Test
+using TimerOutputs: TimerOutput, @timeit
 
 const PKGDIR = string(pkgdir(PlutoStaticHTML))::String
 const NOTEBOOK_DIR = joinpath(PKGDIR, "docs", "src", "notebooks")
@@ -13,7 +14,7 @@ const NOTEBOOK_DIR = joinpath(PKGDIR, "docs", "src", "notebooks")
 function pluto_notebook_content(code)
     return """
         ### A Pluto.jl notebook ###
-        # v0.17.4
+        # v0.18.1
 
         using Markdown
         using InteractiveUtils
@@ -59,5 +60,16 @@ function notebook2html_helper(
     without_cache = has_cache ? drop_cache_info(without_begin_end) : html
 
     return (without_cache, nb)
+end
+
+# Credits to Tensors.jl/test/runtests.jl
+macro timed_testset(str, block)
+    return quote
+        @timeit TIMEROUTPUT "$($(esc(str)))" begin
+            @testset "$($(esc(str)))" begin
+                $(esc(block))
+            end
+        end
+    end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,15 +1,25 @@
 include("preliminaries.jl")
 
-include("context.jl")
-include("cache.jl")
+const TIMEROUTPUT = TimerOutput()
 
-@testset "mimeoverride" begin
+@timed_testset "context" begin
+    include("context.jl")
+end
+
+@timed_testset "cache" begin
+    include("cache.jl")
+end
+
+@timed_testset "mimeoverride" begin
     include("mimeoverride.jl")
 end
 
-@testset "html" begin
+@timed_testset "html" begin
     include("html.jl")
 end
 
-include("build.jl")
+@timed_testset "build" begin
+    include("build.jl")
+end
 
+show(TIMEROUTPUT; compact=true, sortby=:firstexec)


### PR DESCRIPTION
- Closes #67 

Also adds `TimerOutputs.jl` to the tests:

```
 ────────────────────────────────────────────────────────
                              Time          Allocations
                        ───────────────   ───────────────
     Total measured:          181s            4.40GiB

 Section        ncalls     time    %tot     alloc    %tot
 ────────────────────────────────────────────────────────
 context             1    33.9s   18.9%   2.81GiB   65.2%
 cache               1    6.85s    3.8%    597MiB   13.5%
 mimeoverride        1    16.6s    9.2%    195MiB    4.4%
 html                1     115s   64.3%    704MiB   16.0%
 build               1    6.68s    3.7%   39.3MiB    0.9%
 ────────────────────────────────────────────────────────
```