### PR TITLE
Avoid changing pwd when running with `use_distributed=false`

### DIFF
--- a/src/html.jl
+++ b/src/html.jl
@@ -343,12 +343,15 @@ function run_notebook!(
         hopts::HTMLOptions=HTMLOptions(),
         run_async=false
     )
+    # Avoid changing pwd.
+    previous_dir = pwd()
     session.options.server.disable_writing_notebook_files = true
     compiler_options = hopts.compiler_options
     nb = SessionActions.open(session, path; compiler_options, run_async)
     if !run_async
         _throw_if_error(session, nb)
     end
+    cd(previous_dir)
     return nb
 end
 

--- a/test/mimeoverride.jl
+++ b/test/mimeoverride.jl
@@ -1,7 +1,7 @@
 notebook = Notebook([
     Cell("md\"This is **markdown**\"")
 ])
-html, nb = notebook2html_helper(notebook)
+html, nb = notebook2html_helper(notebook; use_distributed=false)
 lines = split(html, '\n')
 @test contains(lines[2], "<strong>")
 
@@ -11,7 +11,7 @@ notebook = Notebook([
     Cell("""[1, (2, (3, 4))]"""),
     Cell("(; a=(1, 2), b=(3, 4))")
 ])
-html, nb = notebook2html_helper(notebook);
+html, nb = notebook2html_helper(notebook; use_distributed=false);
 lines = split(html, '\n')
 @test contains(lines[2], "(\"pluto\", \"tree\", \"object\")")
 @test contains(lines[2], "<pre")

--- a/test/preliminaries.jl
+++ b/test/preliminaries.jl
@@ -43,12 +43,14 @@ end
 "Helper function to simply pass a `nb::Notebook` and run it."
 function notebook2html_helper(
         nb::Notebook,
-        opts=HTMLOptions()
+        opts=HTMLOptions();
+        use_distributed::Bool=true
     )
     tmpdir = mktempdir()
     tmppath = joinpath(tmpdir, "notebook.jl")
     Pluto.save_notebook(nb, tmppath)
     session = ServerSession()
+    session.options.evaluation.workspace_use_distributed = use_distributed
     nb = PlutoStaticHTML.run_notebook!(tmppath, session)
     html = PlutoStaticHTML.notebook2html(nb, tmppath, opts)
 
@@ -72,4 +74,3 @@ macro timed_testset(str, block)
         end
     end
 end
-


### PR DESCRIPTION
- Fix #69 

Also speeds up tests a bit more (-80 seconds) compared to #80. 

```
 ────────────────────────────────────────────────────────
                              Time          Allocations
                        ───────────────   ───────────────
     Total measured:          109s            4.47GiB

 Section        ncalls     time    %tot     alloc    %tot
 ────────────────────────────────────────────────────────
 context             1    37.0s   34.3%   2.81GiB   64.0%
 cache               1    7.12s    6.6%    597MiB   13.3%
 mimeoverride        1    2.37s    2.2%    153MiB    3.4%
 html                1    54.7s   50.8%    827MiB   18.4%
 build               1    6.58s    6.1%   36.7MiB    0.8%
 ──────────────────────────────────────────────────────── 
```