### PR TITLE
Add some precompile statements

### DIFF
--- a/src/build.jl
+++ b/src/build.jl
@@ -278,6 +278,7 @@ function parallel_build(
 
     return H
 end
+precompile(parallel_build, (BuildOptions, Vector{Any}, HTMLOptions))
 
 """
     parallel_build(
@@ -296,4 +297,5 @@ function parallel_build(
     end
     return parallel_build(bopts, files, hopts)
 end
+precompile(parallel_build, (BuildOptions, HTMLOptions))
 

--- a/src/html.jl
+++ b/src/html.jl
@@ -285,6 +285,7 @@ function notebook2html(nb::Notebook, path, hopts::HTMLOptions=HTMLOptions())::St
     html = string(BEGIN_IDENTIFIER, '\n', html, '\n', END_IDENTIFIER)::String
     return html
 end
+precompile(notebook2html, (Notebook, String, HTMLOptions))
 
 const TMP_COPY_PREFIX = "_tmp_"
 
@@ -339,7 +340,7 @@ end
 
 function run_notebook!(
         path::AbstractString,
-        session;
+        session::ServerSession;
         hopts::HTMLOptions=HTMLOptions(),
         run_async=false
     )
@@ -354,6 +355,7 @@ function run_notebook!(
     cd(previous_dir)
     return nb
 end
+precompile(run_notebook!, (String, ServerSession))
 
 """
     notebook2html(
@@ -373,3 +375,4 @@ function notebook2html(
     html = notebook2html(nb, path, hopts)
     return html
 end
+precompile(notebook2html, (String, HTMLOptions))


### PR DESCRIPTION
Reduces Time to First Finish (TTFF) by a second or so on Julia 1.7.2:

```
 ────────────────────────────────────────────────────────
                              Time          Allocations
                        ───────────────   ───────────────
     Total measured:          109s            4.44GiB

 Section        ncalls     time    %tot     alloc    %tot
 ────────────────────────────────────────────────────────
 context             1    35.4s   32.9%   2.74GiB   63.0%
 cache               1    7.47s    6.9%    628MiB   14.1%
 mimeoverride        1    2.33s    2.2%    153MiB    3.4%
 html                1    56.1s   52.0%    828MiB   18.6%
 build               1    6.54s    6.1%   36.7MiB    0.8%
 ──────────────────────────────────────────────────────── 
```

For fun, I've also tested `nightly`:

``` ────────────────────────────────────────────────────────
                              Time          Allocations
                        ───────────────   ───────────────
     Total measured:          162s            3.07GiB

 Section        ncalls     time    %tot     alloc    %tot
 ────────────────────────────────────────────────────────
 context             1    30.1s   18.7%   1.71GiB   56.8%
 cache               1    6.91s    4.3%    502MiB   16.3%
 mimeoverride        1    2.18s    1.4%    144MiB    4.7%
 html                1     115s   71.5%    662MiB   21.4%
 build               1    6.60s    4.1%   23.9MiB    0.8%
 ──────────────────────────────────────────────────────── 
```
Massive reduction in allocations which is great. Longer running time is probably because spawning new processes now takes longer? Could be interesting to investigate further.