### PR TITLE
Change the method name to `build_notebooks`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoStaticHTML"
 uuid = "359b1769-a58e-495b-9770-312e911026ad"
 authors = ["Rik Huijzer <t.h.huijzer@rug.nl>"]
-version = "3.5.1"
+version = "4.0.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,11 +10,11 @@ using PlutoStaticHTML
 const NOTEBOOK_DIR = joinpath(@__DIR__, "src", "notebooks")
 
 """
-    build_notebooks()
+    build()
 
 Run all Pluto notebooks (".jl" files) in `NOTEBOOK_DIR`.
 """
-function build_notebooks()
+function build()
     println("Building notebooks")
     hopts = HTMLOptions(; append_build_context=true)
     output_format = documenter_output
@@ -24,7 +24,7 @@ function build_notebooks()
 end
 
 if !("DISABLE_NOTEBOOK_BUILD" in keys(ENV))
-    build_notebooks()
+    build()
 end
 
 sitename = "PlutoStaticHTML.jl"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,7 +19,7 @@ function build_notebooks()
     hopts = HTMLOptions(; append_build_context=true)
     output_format = documenter_output
     bopts = BuildOptions(NOTEBOOK_DIR; output_format)
-    parallel_build(bopts, hopts)
+    build_notebooks(bopts, hopts)
     return nothing
 end
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,10 +14,10 @@ Also, I'm using this package for my own blog, for example: <https://huijzer.xyz/
 
 ## API overview
 
-The most important method is `parallel_build` ([API](@ref)).
+The most important method is `build_notebooks` ([API](@ref)).
 
 !!! note
-    `parallel_build` ensures that the original notebook will not be changed.
+    `build_notebooks` ensures that the original notebook will not be changed.
 
 In general, the idea is to
 
@@ -25,7 +25,7 @@ In general, the idea is to
 1. Get the name of the directory `dir` which contains your Pluto notebooks.
 1. Choose an appropriate `output_format` depending on how the output will be used.
     The output format can be `html_output`, `documenter_output` or `franklin_output`.
-1. Pass the paths to [`parallel_build`](@ref) which, depending on `output_format`, writes HTML or Markdown outputs to files.
+1. Pass the paths to [`build_notebooks`](@ref) which, depending on `output_format`, writes HTML or Markdown outputs to files.
 1. Read the output from the files and show them on a website via either your own logic or Documenter or Franklin.
 
 Note that this is a very nice development workflow because developing in Pluto notebooks is easy and allows for quick debugging.
@@ -67,18 +67,18 @@ For `output_format=franklin_output` examples, see
 
 ## Parallel build
 
-To speed up the build, this package defines [`parallel_build`](@ref).
+To speed up the build, this package defines [`build_notebooks`](@ref).
 This function evaluates the notebooks in parallel by default.
 Also, it can use [Caching](@ref) to speed up the build even more.
 
 To use it, pass a `dir` to write HTML files for all notebook files (the files are recognized by the ".jl" extension):
 
 ```julia
-julia> using PlutoStaticHTML: parallel_build
+julia> using PlutoStaticHTML: build_notebooks
 
 julia> dir = joinpath("posts", "notebooks");
 
-julia> parallel_build(BuildOptions(dir));
+julia> build_notebooks(BuildOptions(dir));
 [...]
 ```
 
@@ -87,7 +87,7 @@ To run only specific notebooks, use:
 ```julia
 julia> files = ["notebook1.jl", "notebook2.jl"];
 
-julia> parallel_build(BuildOptions(dir), files)
+julia> build_notebooks(BuildOptions(dir), files)
 [...]
 ```
 
@@ -100,18 +100,18 @@ julia> bopts = BuildOptions(dir);
 
 julia> hopts = HTMLOptions(; append_build_context=true);
 
-julia> parallel_build(bopts, files, hopts)
+julia> build_notebooks(bopts, files, hopts)
 [...]
 ```
 
-See [`parallel_build`](@ref) for more information.
+See [`build_notebooks`](@ref) for more information.
 
 ### Caching
 
 Using caching can greatly speed up running times by avoiding to re-evaluate notebooks.
 Caching can be enabled by passing `previous_dir` via [`BuildOptions`](@ref).
 This `previous_dir` should point to a location where HTML or Markdown files are from the previous build.
-Then, `parallel_build` will, for each input file `file.jl`, check:
+Then, `build_notebooks` will, for each input file `file.jl`, check:
 
 1. Whether `joinpath(previous_dir, "file.html")` exists
 2. Whether the SHA checksum of the current `$file.jl` matches the checksum of the previous `$file.jl`.
@@ -136,7 +136,7 @@ For Documenter, see `docs/make.jl` in this repository.
 ## API
 
 ```@docs
-parallel_build
+build_notebooks
 BuildOptions
 HTMLOptions
 ```

--- a/src/PlutoStaticHTML.jl
+++ b/src/PlutoStaticHTML.jl
@@ -41,7 +41,7 @@ include("build.jl")
 
 export HTMLOptions
 export documenter_output, franklin_output, html_output
-export BuildOptions, parallel_build
+export BuildOptions, build_notebooks
 export cell2uuid
 
 # tmp

--- a/src/build.jl
+++ b/src/build.jl
@@ -25,7 +25,7 @@ end
         use_distributed::Bool=true
     )
 
-Options for `parallel_build`:
+Options for `build_notebooks`:
 
 - `dir`:
     Directory in which the Pluto notebooks are stored.
@@ -229,7 +229,7 @@ function _outcome2text(session, nb::Notebook, in_path::String, bopts, hopts)::St
 end
 
 """
-    parallel_build(
+    build_notebooks(
         bopts::BuildOptions,
         files,
         hopts::HTMLOptions=HTMLOptions();
@@ -238,7 +238,7 @@ end
 
 Build all `files` in `dir` in parallel.
 """
-function parallel_build(
+function build_notebooks(
         bopts::BuildOptions,
         files,
         hopts::HTMLOptions=HTMLOptions();
@@ -278,24 +278,30 @@ function parallel_build(
 
     return H
 end
-precompile(parallel_build, (BuildOptions, Vector{Any}, HTMLOptions))
+precompile(build_notebooks, (BuildOptions, Vector{Any}, HTMLOptions))
+
+function _is_pluto_file(path::AbstractString)::Bool
+    first(eachline(string(path))) == "### A Pluto.jl notebook ###"
+end
 
 """
-    parallel_build(
+    build_notebooks(
         bopts::BuildOptions,
         hopts::HTMLOptions=HTMLOptions()
     ) -> Vector{String}
 
 Build all ".jl" files in `dir` in parallel.
 """
-function parallel_build(
+function build_notebooks(
         bopts::BuildOptions,
         hopts::HTMLOptions=HTMLOptions()
     )::Vector{String}
-    files = filter(readdir(bopts.dir)) do file
-        endswith(file, ".jl") && !startswith(file, TMP_COPY_PREFIX)
+    dir = bopts.dir
+    files = filter(readdir(dir)) do file
+        path = joinpath(dir, file)
+        endswith(file, ".jl") && _is_pluto_file(path) && !startswith(file, TMP_COPY_PREFIX)
     end
-    return parallel_build(bopts, files, hopts)
+    return build_notebooks(bopts, files, hopts)
 end
-precompile(parallel_build, (BuildOptions, HTMLOptions))
+precompile(build_notebooks, (BuildOptions, HTMLOptions))
 

--- a/src/module_doc.jl
+++ b/src/module_doc.jl
@@ -9,13 +9,13 @@ let
 
         julia> files = ["notebook1.jl", "notebook2.jl"];
 
-        julia> parallel_build(BuildOptions(dir), files)
+        julia> build_notebooks(BuildOptions(dir), files)
         ```
 
         and to build all notebooks, use:
 
         ```
-        julia> parallel_build(BuildOptions(dir))
+        julia> build_notebooks(BuildOptions(dir))
         ```
 
         See https://rikhuijzer.github.io/PlutoStaticHTML.jl/dev/ for the full documentation.

--- a/test/build.jl
+++ b/test/build.jl
@@ -13,13 +13,31 @@
             write(path, content)
             return file
         end
-        parallel_build(BuildOptions(dir, use_distributed=false))
+        build_notebooks(BuildOptions(dir, use_distributed=false))
 
         html_file = joinpath(dir, "file1.html")
         @test contains(read(html_file, String), "3001")
 
         html_file = joinpath(dir, "file2.html")
         @test contains(read(html_file, String), "3002")
+    end
+end
+
+@testset "is_pluto_file" begin
+    cd(mktempdir()) do
+        nb_text = """
+            ### A Pluto.jl notebook ###
+            # v0.14.0
+            """
+        write("true.jl", nb_text)
+        @test PlutoStaticHTML._is_pluto_file("true.jl")
+
+        jl_text = """
+            module Foo
+            end # module
+            """
+        write("false.jl", jl_text)
+        @test !PlutoStaticHTML._is_pluto_file("false.jl")
     end
 end
 
@@ -30,7 +48,7 @@ end
             file = "file.jl"
             path = joinpath(dir, file)
             write(path, content)
-            parallel_build(BuildOptions(dir), [file], use_distributed=false)
+            build_notebooks(BuildOptions(dir), [file], use_distributed=false)
         end
         error("Test should have failed")
     catch AssertionError

--- a/test/cache.jl
+++ b/test/cache.jl
@@ -50,7 +50,7 @@ end
         write("b.jl", code)
 
         bo = BuildOptions(dir; use_distributed)
-        parallel_build(bo)
+        build_notebooks(bo)
 
         # Without try_read, Pluto in another process may still have a lock on a txt file.
         @test try_read("a.txt") == "a"
@@ -70,7 +70,7 @@ end
             cp(joinpath(previous_dir, "b.jl"), joinpath(dir, "b.jl"))
 
             bo = BuildOptions(dir; use_distributed, previous_dir)
-            parallel_build(bo)
+            build_notebooks(bo)
 
             # a was evaluated because "a.html" was removed.
             # note that pluto always writes txt files to the first dir.
@@ -109,7 +109,7 @@ end
         output_format = html_output
         use_distributed = false
         bo = BuildOptions(dir; output_format, use_distributed)
-        parallel_build(bo)
+        build_notebooks(bo)
 
         output_path = joinpath(dir, "notebook.html")
         output = read(output_path, String)
@@ -119,7 +119,7 @@ end
 
         previous_dir = dir
         bo = BuildOptions(dir; output_format, use_distributed, previous_dir)
-        parallel_build(bo)
+        build_notebooks(bo)
 
         output2 = read(output_path, String)
 
@@ -145,14 +145,14 @@ end
         use_distributed = false
         output_format = franklin_output
         bo = BuildOptions(dir; use_distributed, output_format)
-        parallel_build(bo)
+        build_notebooks(bo)
 
         output_path = joinpath(dir, "notebook.md")
         output = read(output_path, String)
 
         previous_dir = dir
         bo = BuildOptions(dir; output_format, use_distributed, previous_dir)
-        parallel_build(bo)
+        build_notebooks(bo)
 
         output2 = read(output_path, String)
 

--- a/test/context.jl
+++ b/test/context.jl
@@ -8,6 +8,6 @@ write(joinpath(tmpdir, "notebook.jl"), content)
 hopts = HTMLOptions(; append_build_context=true)
 bopts = BuildOptions(tmpdir; use_distributed=true)
 
-html = only(parallel_build(bopts, hopts))
+html = only(build_notebooks(bopts, hopts))
 @test contains(html, r"Built with Julia 1.*")
 @test contains(html, "PrecompileMacro")


### PR DESCRIPTION
The name `parallel_build` was confusing since it was also possible to run a non-parallel build with it. That's now fixed. A second breaking change here is that this PR fixes #78, that is, when calling

```julia
julia> using PlutoStaticHTML

julia> dir = "my/dir/with/notebooks";

julia> build_notebooks(BuildOptions(dir));

```

the method will now silently ignore any `.jl` file that does not start with `### A Pluto.jl notebook ###`. This is useful together with, for example, Franklin where the file `utils.jl` should be ignored.

To override this, it is still possible to call `build_notebooks(BuildOptions(dir), files, hopts)` to force certain `files` to be evaluated.