### PR TITLE
Allow showing output above code

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoStaticHTML"
 uuid = "359b1769-a58e-495b-9770-312e911026ad"
 authors = ["Rik Huijzer <t.h.huijzer@rug.nl>"]
-version = "4.0.0"
+version = "4.0.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/build.jl
+++ b/src/build.jl
@@ -25,7 +25,7 @@ end
         use_distributed::Bool=true
     )
 
-Options for `build_notebooks`:
+Arguments:
 
 - `dir`:
     Directory in which the Pluto notebooks are stored.

--- a/src/html.jl
+++ b/src/html.jl
@@ -23,10 +23,11 @@ const IMAGEMIME = Union{
         hide_md_def_code::Bool=true,
         add_state::Bool=true,
         append_build_context::Bool=false,
-        compiler_options::Union{Nothing,CompilerOptions}=nothing
+        compiler_options::Union{Nothing,CompilerOptions}=nothing,
+        show_output_above_code::Bool=false
     )
 
-Options for `notebook2html`:
+Arguments:
 
 - `code_class`:
     HTML class for code.
@@ -55,6 +56,10 @@ Options for `notebook2html`:
 - `compiler_options`:
     `Pluto.Configuration.CompilerOptions` to be passed to Pluto.
     This can, for example, be useful to pass custom system images from `PackageCompiler.jl`.
+- `show_output_above_code`:
+    Whether to show the output from the code above the code.
+    Pluto.jl shows the output above the code by default; this package shows the output below the code by default.
+    To show the output above the code, set `show_output_above_code=true`.
 """
 struct HTMLOptions
     code_class::String
@@ -66,6 +71,7 @@ struct HTMLOptions
     add_state::Bool
     append_build_context::Bool
     compiler_options::Union{Nothing,CompilerOptions}
+    show_output_above_code::Bool
 
     function HTMLOptions(;
         code_class::AbstractString="language-julia",
@@ -76,7 +82,8 @@ struct HTMLOptions
         hide_md_def_code::Bool=true,
         add_state::Bool=true,
         append_build_context::Bool=false,
-        compiler_options::Union{Nothing,CompilerOptions}=nothing
+        compiler_options::Union{Nothing,CompilerOptions}=nothing,
+        show_output_above_code::Bool=false
     )
         return new(
             string(code_class)::String,
@@ -87,7 +94,8 @@ struct HTMLOptions
             hide_md_def_code,
             add_state,
             append_build_context,
-            compiler_options
+            compiler_options,
+            show_output_above_code
         )
     end
 end
@@ -251,10 +259,17 @@ _output2html(cell::Cell, T::MIME, hopts) = error("Unknown type: $T")
 function _cell2html(cell::Cell, hopts::HTMLOptions)
     code = _code2html(cell.code, hopts)
     output = _output2html(cell, cell.output.mime, hopts)
-    return """
-        $code
-        $output
-        """
+    if hopts.show_output_above_code
+        return """
+            $output
+            $code
+            """
+    else
+        return """
+            $code
+            $output
+            """
+    end
 end
 
 const BEGIN_IDENTIFIER = "<!-- PlutoStaticHTML.Begin -->"

--- a/test/html.jl
+++ b/test/html.jl
@@ -134,3 +134,15 @@ end
     html, nb = notebook2html_helper(nb)
     @test contains(html, "BenchmarkTools.Trial")
 end
+
+@testset "show_output_above_code" begin
+    notebook = Notebook([
+        Cell("x = 1 + 1020"),
+    ])
+    hopts = HTMLOptions(; show_output_above_code=true)
+    html, nb = notebook2html_helper(notebook, hopts; use_distributed=false)
+    lines = split(html, '\n')
+
+    @test contains(lines[1], "1021")
+    @test contains(lines[2], "1 + 1020")
+end

--- a/test/preliminaries.jl
+++ b/test/preliminaries.jl
@@ -43,7 +43,7 @@ end
 "Helper function to simply pass a `nb::Notebook` and run it."
 function notebook2html_helper(
         nb::Notebook,
-        opts=HTMLOptions();
+        hopts=HTMLOptions();
         use_distributed::Bool=true
     )
     tmpdir = mktempdir()
@@ -52,7 +52,7 @@ function notebook2html_helper(
     session = ServerSession()
     session.options.evaluation.workspace_use_distributed = use_distributed
     nb = PlutoStaticHTML.run_notebook!(tmppath, session)
-    html = PlutoStaticHTML.notebook2html(nb, tmppath, opts)
+    html = PlutoStaticHTML.notebook2html(nb, tmppath, hopts)
 
     has_begin_end = contains(html, PlutoStaticHTML.BEGIN_IDENTIFIER)
     without_begin_end = has_begin_end ? drop_begin_end(html) : html


### PR DESCRIPTION
This PR adds a new setting `show_output_above_code` which allows showing the output of a code block **above** the code instead of below.

@MichaelHatherly I haven't added any styling for this case yet, but I guess you will be doing styling on your side anyway? I try to avoid hardcoding styling inside the HTML output because it could be hard to override for end-users. (But then again, maybe I should because CSS does allow `!important` annotations.)