### PR TITLE
Disable syntax highlight for output blocks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoStaticHTML"
 uuid = "359b1769-a58e-495b-9770-312e911026ad"
 authors = ["Rik Huijzer <t.h.huijzer@rug.nl>"]
-version = "4.2.0"
+version = "5.0.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/src/notebooks/example.jl
+++ b/docs/src/notebooks/example.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.18.0
+# v0.19.0
 
 using Markdown
 using InteractiveUtils
@@ -14,6 +14,9 @@ The web page that you're looking is generated from a Pluto notebook.
 
 # ╔═╡ 058a7f63-7058-4229-b40c-2e98264bd77f
 1 + 1
+
+# ╔═╡ ee8c85f0-6612-4515-89a8-af04298c48bc
+(; title="a namedtuple", values=[1, 2, 3])
 
 # ╔═╡ 7ca85dab-6066-4b2a-b61c-9d9607b8756c
 lines(1:10, 1:10)
@@ -1178,6 +1181,7 @@ version = "3.5.0+0"
 # ╔═╡ Cell order:
 # ╠═751853f6-626f-4040-86b2-088339ef9a3c
 # ╠═058a7f63-7058-4229-b40c-2e98264bd77f
+# ╠═ee8c85f0-6612-4515-89a8-af04298c48bc
 # ╠═3dd303b0-373e-11ec-18e4-69bfc20b5e29
 # ╠═7ca85dab-6066-4b2a-b61c-9d9607b8756c
 # ╠═4ca09326-c8d8-44fb-8582-8dcc071bc76a

--- a/src/build.jl
+++ b/src/build.jl
@@ -192,6 +192,10 @@ function _add_documenter_css(html)
                 margin-top: 1.4rem !important;
                 margin-bottom: 1.4rem !important;
             }
+
+            .code-output {
+                padding: 0.7rem 0.5rem !important;
+            }
         </style>
         """
     return string(style, '\n', html)

--- a/src/html.jl
+++ b/src/html.jl
@@ -14,8 +14,7 @@ const IMAGEMIME = Union{
 }
 
 const CODE_CLASS_DEFAULT = "language-julia"
-const OUTPUT_CLASS_DEFAULT = "code-output"
-const OUTPUT_PRE_CLASS_DEFAULT = "documenter-example-output"
+const OUTPUT_PRE_CLASS_DEFAULT = "code-output documenter-example-output"
 const HIDE_CODE_DEFAULT = false
 const HIDE_MD_CODE_DEFAULT = true
 const HIDE_MD_DEF_CODE_DEFAULT = true
@@ -28,8 +27,7 @@ const REPLACE_CODE_TABS_DEFAULT = true
 """
     HTMLOptions(;
         code_class::AbstractString="$CODE_CLASS_DEFAULT",
-        output_class::AbstractString="$OUTPUT_CLASS_DEFAULT",
-        output_pre_class::AbstractString="$OUTPUT_CLASS_DEFAULT",
+        output_pre_class::AbstractString="$OUTPUT_PRE_CLASS_DEFAULT",
         hide_code::Bool=$HIDE_CODE_DEFAULT,
         hide_md_code::Bool=$HIDE_MD_CODE_DEFAULT,
         hide_md_def_code::Bool=$HIDE_MD_DEF_CODE_DEFAULT,
@@ -80,7 +78,6 @@ Arguments:
 struct HTMLOptions
     code_class::String
     output_pre_class::String
-    output_class::String
     hide_code::Bool
     hide_md_code::Bool
     hide_md_def_code::Bool
@@ -93,7 +90,6 @@ struct HTMLOptions
     function HTMLOptions(;
         code_class::AbstractString=CODE_CLASS_DEFAULT,
         output_pre_class::AbstractString=OUTPUT_PRE_CLASS_DEFAULT,
-        output_class::AbstractString=OUTPUT_CLASS_DEFAULT,
         hide_code::Bool=HIDE_CODE_DEFAULT,
         hide_md_code::Bool=HIDE_MD_CODE_DEFAULT,
         hide_md_def_code::Bool=HIDE_MD_DEF_CODE_DEFAULT,
@@ -106,7 +102,6 @@ struct HTMLOptions
         return new(
             string(code_class)::String,
             string(output_pre_class)::String,
-            string(output_class)::String,
             hide_code,
             hide_md_code,
             hide_md_def_code,
@@ -140,12 +135,12 @@ function code_block(code; pre_class="language-julia", code_class="")
     return "<pre class='$pre_class'><code class='$code_class'>$code</code></pre>"
 end
 
-function output_block(s; class="code-output", pre_class="pre-class", var="")
+function output_block(s; output_pre_class="pre-class", var="")
     if s == ""
         return ""
     end
     id = var == "" ? "" : "id='var-$var'"
-    return "<pre $id class='$pre_class'><code class='$class'>$s</code></pre>"
+    return "<pre $id class='$output_pre_class'>$s</pre>"
 end
 
 "Replace tabs by spaces in code blocks."
@@ -266,8 +261,7 @@ function _output2html(cell::Cell, ::MIME"text/plain", hopts)
         # Go back into Markdown mode instead of HTML
         return string("~~~\n", body, "\n~~~")
     end
-    pre_class = hopts.output_pre_class
-    output_block(body; pre_class, var)
+    output_block(body; hopts.output_pre_class, var)
 end
 
 function _output2html(cell::Cell, ::MIME"text/html", hopts)

--- a/test/html.jl
+++ b/test/html.jl
@@ -15,7 +15,7 @@
 
     @test contains(lines[1], "1 + 1")
     @test contains(lines[2], "2")
-    @test contains(lines[2], "class='documenter-example-output'")
+    @test contains(lines[2], "class='$(PlutoStaticHTML.OUTPUT_PRE_CLASS_DEFAULT)'")
 
     @test contains(lines[end-1], """<img src=\"data:image/png;base64,""")
 


### PR DESCRIPTION
This changes the output from a `code` block to a `pre` block only. This way, syntax highlighters will not put non-fitting colors in the output block. I've tried to use a `nohighlight` class and all kinds of variations, but it didn't work.

- Fixes #92 

I've made this a major breaking release because it will require some CSS styling to be updated in some cases. For people who use the default Documenter styling, this release can be used without problems.