### PR TITLE
Limit concurrency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoStaticHTML"
 uuid = "359b1769-a58e-495b-9770-312e911026ad"
 authors = ["Rik Huijzer <t.h.huijzer@rug.nl>"]
-version = "5.0.0"
+version = "5.0.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
Closes #36.

Slowly but surely, my blog is containing more and more notebooks. When doing a full run over all the 12 notebooks, my PC ended up being unusable because `PlutoStaticHTML.jl` was spawning too many threads causing all time to be spent switching between tasks instead of doing productive work. I thought that `Pluto.jl` took care of this, but that is apparently not the case.

This PR fixes the problem by starting multiple async `Pluto.jl` evaluations via `Threads.@threads`. In each loop, `PlutoStaticHTML.jl` will wait for the async task to finish before starting more notebooks.

I've tested this functionality on my blog posts. Indeed, it nicely starts 6 notebooks and waits for one to finish before starting new notebooks. I'm typing this while the processes keep my PC busy at around 100%. Still, the PC isn't grinding to a halt like I had yesterday, so all appears to work as expected :rocket: :balloon: 