### PR TITLE
Add `max_concurrent_runs` setting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoStaticHTML"
 uuid = "359b1769-a58e-495b-9770-312e911026ad"
 authors = ["Rik Huijzer <t.h.huijzer@rug.nl>"]
-version = "5.0.1"
+version = "5.0.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
Unfortunately, #98 turned out to be a bit of a failure. It worked locally, but ran into https://github.com/JuliaLang/Downloads.jl/issues/94 in CI. Luckily, starting multiple threads actually was a bit dumb because `PlutoStaticHTML.jl` then starts threads in which `Pluto.jl` starts more threads. This PR aims to fix that by starting the threads from with asynchronous tasks (coroutines) instead of threads. As it turns out, there is a nice Julia function `asyncmap` exactly for this purpose.

This PR also adds a new `BuildOptions` setting called `max_concurrent_runs` which specifies how many notebooks can be evaluated concurrently. This defaults to 4 to be on the safe side in case a notebook starts multiple threads too and overwhelms the system.

- Related issue: #36.