### PR TITLE
Revert incremental compilation fix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoStaticHTML"
 uuid = "359b1769-a58e-495b-9770-312e911026ad"
 authors = ["Rik Huijzer <t.h.huijzer@rug.nl>"]
-version = "5.0.3"
+version = "5.0.4"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/PlutoStaticHTML.jl
+++ b/src/PlutoStaticHTML.jl
@@ -35,6 +35,7 @@ using TOML: parse as parsetoml
 include("module_doc.jl")
 include("context.jl")
 include("cache.jl")
+include("mimeoverride.jl")
 include("with_terminal.jl")
 include("html.jl")
 include("style.jl")
@@ -44,17 +45,5 @@ export HTMLOptions
 export documenter_output, franklin_output, html_output
 export BuildOptions, build_notebooks
 export cell2uuid
-
-# tmp
-export __build
-export _cell
-export __notebook
-
-function __init__()
-    # Loading the mimeoverrides in `__init__` to avoid "incremental compilation may be
-    # fatally broken for this module" errors.
-    path = joinpath(pkgdir(PlutoStaticHTML), "src", "mimeoverride.jl")
-    include(path)
-end
 
 end # module


### PR DESCRIPTION
Unfortunately the fix of #100 causes problems:

```
ERROR: LoadError: InitError: LoadError: Evaluation into the closed module `PlutoStaticHTML` breaks incremental compilation because the side effects will not be permanent. This is likely due to some other module mutating `PlutoStaticHTML` with `eval` during precompilation - don't do this.
```

So, the only solution seems to be to add a configuration to `Pluto.jl`.