### PR TITLE
Use PrecompileSignatures.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoStaticHTML"
 uuid = "359b1769-a58e-495b-9770-312e911026ad"
 authors = ["Rik Huijzer <t.h.huijzer@rug.nl>"]
-version = "5.0.5"
+version = "5.0.6"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -7,9 +7,11 @@ version = "5.0.5"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
+PrecompileSignatures = "91cefc8d-f054-46dc-8f8c-26e11d7c5411"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 Pluto = "=0.19.2"
+PrecompileSignatures = "1"
 julia = "1.6"

--- a/src/PlutoStaticHTML.jl
+++ b/src/PlutoStaticHTML.jl
@@ -29,6 +29,7 @@ using Pluto:
     update_dependency_cache!,
     update_run!,
     update_save_run!
+using PrecompileSignatures: precompile_directives
 using SHA: sha256
 using TOML: parse as parsetoml
 
@@ -45,6 +46,9 @@ include("documenter.jl")
 export HTMLOptions
 export documenter_output, franklin_output, html_output
 export BuildOptions, build_notebooks
-export cell2uuid
+
+if ccall(:jl_generating_output, Cint, ()) == 1
+    include(precompile_directives(PlutoStaticHTML))
+end
 
 end # module

--- a/src/build.jl
+++ b/src/build.jl
@@ -327,7 +327,6 @@ function build_notebooks(
 
     return H
 end
-precompile(build_notebooks, (BuildOptions, Vector{Any}, HTMLOptions))
 
 function _is_pluto_file(path::AbstractString)::Bool
     first(eachline(string(path))) == "### A Pluto.jl notebook ###"
@@ -352,5 +351,3 @@ function build_notebooks(
     end
     return build_notebooks(bopts, files, hopts)
 end
-precompile(build_notebooks, (BuildOptions, HTMLOptions))
-

--- a/src/html.jl
+++ b/src/html.jl
@@ -345,7 +345,6 @@ function notebook2html(nb::Notebook, path, hopts::HTMLOptions=HTMLOptions())::St
     html = string(BEGIN_IDENTIFIER, '\n', html, '\n', END_IDENTIFIER)::String
     return html
 end
-precompile(notebook2html, (Notebook, String, HTMLOptions))
 
 const TMP_COPY_PREFIX = "_tmp_"
 
@@ -415,7 +414,6 @@ function run_notebook!(
     cd(previous_dir)
     return nb
 end
-precompile(run_notebook!, (String, ServerSession))
 
 """
     notebook2html(
@@ -435,4 +433,3 @@ function notebook2html(
     html = notebook2html(nb, path, hopts)
     return html
 end
-precompile(notebook2html, (String, HTMLOptions))

--- a/src/with_terminal.jl
+++ b/src/with_terminal.jl
@@ -17,4 +17,3 @@ function _patch_with_terminal(body::String)
         </pre>
         """
 end
-precompile(_patch_with_terminal, (String,))


### PR DESCRIPTION
No real performance difference. It just replaces the manually added `precompile` directives by having them auto-generated by [`PrecompileSignatures.jl`](https://github.com/rikhuijzer/PrecompileSignatures.jl).