### PR TITLE
Handle truncated tables better

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 **/_tmp_*
 docs/src/dynamic/
 **/*backup*.jl
+tmp.*

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoStaticHTML"
 uuid = "359b1769-a58e-495b-9770-312e911026ad"
 authors = ["Rik Huijzer <t.h.huijzer@rug.nl>"]
-version = "5.0.8"
+version = "5.0.9"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -13,6 +13,6 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
-Pluto = "=0.19.4"
+Pluto = "=0.19.5"
 PrecompileSignatures = "3"
 julia = "1.6"

--- a/src/html.jl
+++ b/src/html.jl
@@ -222,7 +222,7 @@ function _output2html(cell::Cell, ::MIME"application/vnd.pluto.table+object", ho
         catch
             first.(first.(row))
         end
-        if eltype(elements) != Char && wide_truncated && eltype(elements) != Char
+        if eltype(elements) != Char && wide_truncated
             elements[end] = ""
         end
         eltype(index) != Char ? pushfirst!(elements, string(index)::String) : ""

--- a/src/html.jl
+++ b/src/html.jl
@@ -225,7 +225,6 @@ function _output2html(cell::Cell, ::MIME"application/vnd.pluto.table+object", ho
         if eltype(elements) != Char && wide_truncated && eltype(elements) != Char
             elements[end] = ""
         end
-        @show typeof(row[1])
         eltype(index) != Char ? pushfirst!(elements, string(index)::String) : ""
         elements = ["<td>$e</td>" for e in elements]
         return _tr_wrap(elements)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/html.jl
+++ b/test/html.jl
@@ -186,3 +186,14 @@ end
     @test contains(lines[2], "        b = 1 + 1021")
 end
 
+@testset "big table" begin
+    # Using DataFrames here instead of Tables to get the number of rows for long tables.
+    nb = Notebook([
+        Cell("using DataFrames: DataFrame"),
+        Cell("DataFrame(rand(120, 20), :auto)")
+    ])
+    hopts = HTMLOptions()
+    html, _ = notebook2html_helper(nb, hopts; use_distributed=false)
+    # Use write(tmp.html, html) to test this.
+    
+end

--- a/test/html.jl
+++ b/test/html.jl
@@ -186,7 +186,7 @@ end
     @test contains(lines[2], "        b = 1 + 1021")
 end
 
-@testset "big table" begin
+@testset "big-table" begin
     # Using DataFrames here instead of Tables to get the number of rows for long tables.
     nb = Notebook([
         Cell("using DataFrames: DataFrame"),
@@ -194,6 +194,20 @@ end
     ])
     hopts = HTMLOptions()
     html, _ = notebook2html_helper(nb, hopts; use_distributed=false)
-    # Use write(tmp.html, html) to test this.
-    
+    # Use write(tmp.html, html) to look at this.
+
+    # First column is empty in the header (because of indexes).
+    @test contains(html, """
+        <table>
+        <tr>
+        <th></th>
+        """)
+    # At least one of the rows contains three dots.
+    @test contains(html, "<th>...</th>\n</tr>")
+
+    # The number of rows is shown.
+    @test contains(html, "<td>120</td>")
+
+    # If not being careful, the first element of the last column is taken, so "more" becomes "m".
+    @test !contains(html, "<td>m</td>")
 end

--- a/test/preliminaries.jl
+++ b/test/preliminaries.jl
@@ -1,3 +1,4 @@
+using DataFrames: DataFrame
 using Dates
 using PlutoStaticHTML
 using Pluto:


### PR DESCRIPTION
- Fixes #113 
- Fixes #114 

Also moves to the newest Pluto version again (not that it should make a difference though. There wasn't anything merged there related to Pluto's internal APIs that PlutoStaticHTML uses)