### PR TITLE
Improve error message if file is not found

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoStaticHTML"
 uuid = "359b1769-a58e-495b-9770-312e911026ad"
 authors = ["Rik Huijzer <t.h.huijzer@rug.nl>"]
-version = "5.0.9"
+version = "5.0.10"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/build.jl
+++ b/src/build.jl
@@ -276,7 +276,11 @@ end
 function _evaluate_file(bopts::BuildOptions, hopts::HTMLOptions, session, in_file, time_state)
     dir = bopts.dir
     in_path = joinpath(dir, in_file)::String
-    @assert isfile(in_path) "Expected .jl file at $in_path"
+
+    # Check whether file exists
+    @assert isfile(in_path) "File not found: `$in_file`"
+    # Check that it is a Julia file
+    @assert (string(splitext(in_file)[2]) == ".jl") "File does not seem to be a Julia (.jl) file: $in_file"
 
     previous = Previous(bopts, in_file)
     if reuse_previous(previous, dir, in_file)

--- a/src/build.jl
+++ b/src/build.jl
@@ -277,10 +277,8 @@ function _evaluate_file(bopts::BuildOptions, hopts::HTMLOptions, session, in_fil
     dir = bopts.dir
     in_path = joinpath(dir, in_file)::String
 
-    # Check whether file exists
-    @assert isfile(in_path) "File not found: `$in_file`"
-    # Check that it is a Julia file
-    @assert (string(splitext(in_file)[2]) == ".jl") "File does not seem to be a Julia (.jl) file: $in_file"
+    @assert isfile(in_path) "File not found at `$in_file`"
+    @assert (string(splitext(in_file)[2]) == ".jl") "File doesn't have a `.jl` extension: $in_file"
 
     previous = Previous(bopts, in_file)
     if reuse_previous(previous, dir, in_file)

--- a/src/build.jl
+++ b/src/build.jl
@@ -277,8 +277,8 @@ function _evaluate_file(bopts::BuildOptions, hopts::HTMLOptions, session, in_fil
     dir = bopts.dir
     in_path = joinpath(dir, in_file)::String
 
-    @assert isfile(in_path) "File not found at `$in_file`"
-    @assert (string(splitext(in_file)[2]) == ".jl") "File doesn't have a `.jl` extension: $in_file"
+    @assert isfile(in_path) "File not found at $in_path"
+    @assert (string(splitext(in_file)[2]) == ".jl") "File doesn't have a `.jl` extension at $in_path"
 
     previous = Previous(bopts, in_file)
     if reuse_previous(previous, dir, in_file)


### PR DESCRIPTION
This PR solves #122 by providing two error messages, one if the file is not found, one if the file is not a Julia file.

Let me know if I missed something here; locally all tests ran fine, but I could not find a coding style