### PR TITLE
Fix Markdown code loading again

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoStaticHTML"
 uuid = "359b1769-a58e-495b-9770-312e911026ad"
 authors = ["Rik Huijzer <t.h.huijzer@rug.nl>"]
-version = "5.0.11"
+version = "5.0.12"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/mimeoverride.jl
+++ b/src/mimeoverride.jl
@@ -16,6 +16,10 @@ const show_richest_override = quote
             end
         end
 
+        # Calling Markdown here to be sure that it works.
+        markdown_pkg = Base.PkgId(Base.UUID("d6f4376e-aef5-505a-96c1-9c027394607a"), "Markdown")
+        Markdown = Base.loaded_modules[markdown_pkg]
+
         if mime in PlutoRunner.imagemimes
             show(io, mime, x)
             nothing, mime

--- a/test/html.jl
+++ b/test/html.jl
@@ -186,12 +186,6 @@ end
     @test contains(lines[2], "        b = 1 + 1021")
 end
 
-@testset "smoke test latex in override" begin
-    nb = Notebook([Cell("md\"\$bar\$ foo\"")])
-    html, _ = notebook2html_helper(nb, HTMLOptions(); use_distributed=false)
-    html, _ = notebook2html_helper(nb, HTMLOptions(); use_distributed=true)
-end
-
 @testset "big-table" begin
     # Using DataFrames here instead of Tables to get the number of rows for long tables.
     nb = Notebook([

--- a/test/html.jl
+++ b/test/html.jl
@@ -186,6 +186,12 @@ end
     @test contains(lines[2], "        b = 1 + 1021")
 end
 
+@testset "smoke test latex in override" begin
+    nb = Notebook([Cell("md\"\$bar\$ foo\"")])
+    html, _ = notebook2html_helper(nb, HTMLOptions(); use_distributed=false)
+    html, _ = notebook2html_helper(nb, HTMLOptions(); use_distributed=true)
+end
+
 @testset "big-table" begin
     # Using DataFrames here instead of Tables to get the number of rows for long tables.
     nb = Notebook([


### PR DESCRIPTION
Fixes #125 for when `use_distributed=true`. The fix loads the symbol from `Base.loaded_modules` which obviously shouldn't be done. However, this is because `eval(:(using Markdown))` fails in the distributed worker. A better and "final" solution will be #85 (which I know how to do on paper thanks to a discussion with Fons, I just need to find a few hours of focus time to dive into it)