### PR TITLE
Handle cell metadata

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoStaticHTML"
 uuid = "359b1769-a58e-495b-9770-312e911026ad"
 authors = ["Rik Huijzer <project@huijzer.xyz>"]
-version = "6.0.4"
+version = "6.0.5"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/html.jl
+++ b/src/html.jl
@@ -27,10 +27,11 @@ function output_block(s; output_pre_class="pre-class", var="")
     return "<pre $id class='$output_pre_class'>$s</pre>"
 end
 
-function _code2html(code::AbstractString, oopts::OutputOptions)
-    if oopts.hide_code
+function _code2html(cell::Cell, oopts::OutputOptions)
+    if oopts.hide_code || cell.code_folded
         return ""
     end
+    code = cell.code
     if oopts.hide_md_code && startswith(code, "md\"")
         return ""
     end
@@ -157,7 +158,10 @@ end
 _output2html(cell::Cell, T::MIME, oopts) = error("Unknown type: $T")
 
 function _cell2html(cell::Cell, oopts::OutputOptions)
-    code = _code2html(cell.code, oopts)
+    if cell.metadata["disabled"]
+        return ""
+    end
+    code = _code2html(cell, oopts)
     output = _output2html(cell, cell.output.mime, oopts)
     if oopts.convert_admonitions
         output = _convert_admonitions(output)

--- a/test/html.jl
+++ b/test/html.jl
@@ -218,3 +218,20 @@ end
     # If not being careful, the first element of the last column is taken, so "more" becomes "m".
     @test !contains(html, "<td>m</td>")
 end
+
+@testset "handle cell metadata" begin
+    nb = Notebook([
+        Cell("a = 1000 + 1"),
+        Cell("b = 2000 + 1"),
+        Cell("c = 3000 + 1")
+    ])
+    nb.cells[1].code_folded = true
+    nb.cells[2].metadata["disabled"] = true
+    html, _ = notebook2html_helper(nb)
+
+    @test !contains(html, "1000 + 1")
+    @test contains(html, "1001")
+
+    @test !contains(html, "2000 + 1")
+    @test !contains(html, "2001")
+end


### PR DESCRIPTION
Hide code blocks when `cell.code_folded` and hide code blocks and output when `cell.metadata["disabled"]`. Without these changes, having a disabled cell would actually throw an error. 

- Fixes  #149