### PR TITLE
Avoid benign warning

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoStaticHTML"
 uuid = "359b1769-a58e-495b-9770-312e911026ad"
 authors = ["Rik Huijzer <project@huijzer.xyz>"]
-version = "6.0.7"
+version = "6.0.8"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/build.jl
+++ b/src/build.jl
@@ -357,8 +357,9 @@ function run_notebook!(
 end
 
 function _add_extra_preamble!(session::ServerSession)
-    if !isnothing(session.options.evaluation.workspace_custom_startup_expr)
-        @warn "Expected the `workspace_custom_startup_expr` setting to not be set; overriding it."
+    current = session.options.evaluation.workspace_custom_startup_expr
+    if current !== nothing && current != CONFIG_PLUTORUNNER
+        @warn "Expected the `workspace_custom_startup_expr` setting to not be set by someone else; overriding it."
     end
     session.options.evaluation.workspace_custom_startup_expr = CONFIG_PLUTORUNNER
     return session


### PR DESCRIPTION
When running `PlutoStaticHTML` for the second time, it warns that:

```
┌ Warning: Expected the `workspace_custom_startup_expr` setting to not be set; overriding it.
└ @ PlutoStaticHTML ~/.julia/packages/PlutoStaticHTML/mbTR3/src/build.jl:361
```

This is a benign case because the the expression will not be changed (before == after).