### PR TITLE
Avoid `startswith(Nothing, ...)` error

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoStaticHTML"
 uuid = "359b1769-a58e-495b-9770-312e911026ad"
 authors = ["Rik Huijzer <project@huijzer.xyz>"]
-version = "6.0.12"
+version = "6.0.13"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/html.jl
+++ b/src/html.jl
@@ -127,7 +127,7 @@ end
 
 function _output2html(cell::Cell, ::MIME"text/plain", oopts)
     var = _var(cell)
-    body = cell.output.body
+    body = string(cell.output.body)::String
     # `+++` means that it is a cell with Franklin definitions.
     if oopts.hide_md_def_code && startswith(body, "+++")
         # Go back into Markdown mode instead of HTML
@@ -137,10 +137,10 @@ function _output2html(cell::Cell, ::MIME"text/plain", oopts)
 end
 
 function _output2html(cell::Cell, ::MIME"text/html", oopts)
-    body = cell.output.body
+    body = string(cell.output.body)::String
 
     if contains(body, """<script type="text/javascript" id="plutouiterminal">""")
-        return _patch_with_terminal(string(body))
+        return _patch_with_terminal(body)
     end
 
     # The docstring is already visible in Markdown and shouldn't be shown below the code.

--- a/src/pdf.jl
+++ b/src/pdf.jl
@@ -39,7 +39,7 @@ function tex_output_block(text::String)
 end
 
 function _output2tex(cell::Cell, ::MIME"text/plain", oopts::OutputOptions)
-    body = cell.output.body
+    body = string(cell.output.body)::String
     # `+++` means that it is a cell with Franklin definitions.
     if oopts.hide_md_def_code && startswith(body, "+++")
         return ""


### PR DESCRIPTION
This PR fixes a bug which occurs in some cases. Probably when one of the Pluto cells is empty.

(Sometimes I wish for a powerful type checker because this bug could have been avoided.)
