### PR TITLE
Probably fix CSS styling

### DIFF
--- a/src/style.jl
+++ b/src/style.jl
@@ -2,14 +2,14 @@
 function _add_documenter_css(html)
     style = """
         <style>
-            table {
+            #documenter-page table {
                 display: table !important;
                 margin: 2rem auto !important;
                 border-top: 2pt solid rgba(0,0,0,0.2);
                 border-bottom: 2pt solid rgba(0,0,0,0.2);
             }
 
-            pre, div {
+            #documenter-page pre, #documenter-page div {
                 margin-top: 1.4rem !important;
                 margin-bottom: 1.4rem !important;
             }


### PR DESCRIPTION
Related to #143. I have to push this first because I cannot reproduce the issue locally.

One page which shows the issue is https://plutostatichtml.huijzer.xyz/stable/notebooks/example/:

![image](https://github.com/rikhuijzer/PlutoStaticHTML.jl/assets/20724914/176b71b7-16d5-4594-a7d9-701f82ac4ef1)
